### PR TITLE
Enhance cached media handling and playback controls

### DIFF
--- a/src/main/config.mjs
+++ b/src/main/config.mjs
@@ -13,7 +13,8 @@ export const store = new Store({
       wrapStyle: 2
     },
     // 新增：cookies 路徑（Netscape cookies.txt）
-    cookiesPath: ''
+    cookiesPath: '',
+    downloads: []
   }
 });
 

--- a/src/main/ipc.mjs
+++ b/src/main/ipc.mjs
@@ -2,13 +2,154 @@ import { app, ipcMain, dialog } from 'electron';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import { checkAndOfferDownload, getBinPaths } from './binManager.mjs';
 import { getConfig, setConfig, store } from './config.mjs';
 import { updateOverlayState } from './main.mjs';
 
 let dlSeq = 0;
 const running = new Map(); // jobId -> child
+
+const AUDIO_EXTS = new Set(['.mp3', '.m4a', '.aac', '.flac', '.wav', '.ogg', '.opus', '.wma']);
+
+const getVideoCacheDir = () => path.join(app.getPath('userData'), 'video-cache');
+const getSubsCacheDir = () => path.join(app.getPath('userData'), 'subs-cache');
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function readDownloadStore() {
+  const downloads = store.get('downloads');
+  return Array.isArray(downloads) ? downloads : [];
+}
+
+function writeDownloadStore(entries) {
+  store.set('downloads', entries);
+}
+
+async function buildDownloadEntry(raw) {
+  if (!raw) return null;
+  const videoDir = getVideoCacheDir();
+  const subsDir = getSubsCacheDir();
+  const addedAt = raw.addedAt || Date.now();
+  const updatedAt = raw.updatedAt || addedAt;
+  let id = raw.id || '';
+  const videoFilename = raw.videoFilename || '';
+  const subsFilename = raw.subsFilename || '';
+  if (!id) id = videoFilename || subsFilename || `entry_${addedAt}`;
+  const title = raw.title || '';
+
+  let videoPath = '';
+  let hasVideo = false;
+  if (videoFilename) {
+    const p = path.join(videoDir, videoFilename);
+    try {
+      const st = await fs.stat(p);
+      if (st.isFile()) {
+        videoPath = p;
+        hasVideo = true;
+      }
+    } catch { }
+  }
+
+  let subsPath = '';
+  let hasSubs = false;
+  if (subsFilename) {
+    const p = path.join(subsDir, subsFilename);
+    try {
+      const st = await fs.stat(p);
+      if (st.isFile()) {
+        subsPath = p;
+        hasSubs = true;
+      }
+    } catch { }
+  }
+
+  let mediaKind = 'video';
+  if (hasVideo) {
+    const ext = path.extname(videoFilename).toLowerCase();
+    if (AUDIO_EXTS.has(ext)) mediaKind = 'audio';
+  }
+
+  const displayTitle = title || (hasVideo
+    ? path.parse(videoFilename).name
+    : hasSubs
+      ? path.parse(subsFilename).name
+      : id);
+
+  return {
+    id,
+    title,
+    displayTitle,
+    addedAt,
+    updatedAt,
+    videoFilename,
+    subsFilename,
+    videoPath,
+    subsPath,
+    hasVideo,
+    hasSubs,
+    mediaKind
+  };
+}
+
+async function listDownloadEntries() {
+  const entries = await Promise.all(readDownloadStore().map(buildDownloadEntry));
+  return entries
+    .filter((item) => item && (item.hasVideo || item.hasSubs))
+    .sort((a, b) => (a?.addedAt || 0) - (b?.addedAt || 0));
+}
+
+async function upsertDownloadEntry(patch = {}) {
+  const now = Date.now();
+  const downloads = readDownloadStore();
+  let idx = -1;
+  if (patch.id) idx = downloads.findIndex(item => item?.id === patch.id);
+  if (idx < 0 && patch.videoFilename) {
+    idx = downloads.findIndex(item => item?.videoFilename === patch.videoFilename);
+  }
+  if (idx < 0 && patch.subsFilename) {
+    idx = downloads.findIndex(item => item?.subsFilename === patch.subsFilename);
+  }
+  const base = idx >= 0 ? downloads[idx] : {};
+  const id = patch.id || base.id || patch.videoFilename || patch.subsFilename || `entry_${now}`;
+  const addedAt = base.addedAt || now;
+  const merged = {
+    ...base,
+    ...patch,
+    id,
+    addedAt,
+    updatedAt: now
+  };
+  if (idx >= 0) downloads[idx] = merged;
+  else downloads.push(merged);
+  writeDownloadStore(downloads);
+  return buildDownloadEntry(merged);
+}
+
+async function registerVideoDownload({ id, title, filename }) {
+  if (!filename) return null;
+  await ensureDir(getVideoCacheDir());
+  return upsertDownloadEntry({ id, title, videoFilename: filename });
+}
+
+async function registerSubtitleDownload({ id, title, sourcePath }) {
+  if (!sourcePath) return null;
+  const subsDir = getSubsCacheDir();
+  await ensureDir(subsDir);
+  const ext = path.extname(sourcePath) || '.ass';
+  const normalizedName = id ? `${id}${ext}` : path.basename(sourcePath);
+  const targetPath = path.join(subsDir, normalizedName);
+  try {
+    if (path.resolve(sourcePath) !== targetPath) {
+      await fs.copyFile(sourcePath, targetPath);
+      await fs.unlink(sourcePath).catch(() => { });
+    } else if (path.basename(sourcePath) !== normalizedName) {
+      await fs.rename(sourcePath, targetPath);
+    }
+  } catch { }
+  return upsertDownloadEntry({ id, title, subsFilename: path.basename(targetPath) });
+}
 
 function run(cmd, args, opts = {}) {
   return new Promise((resolve, reject) => {
@@ -51,29 +192,58 @@ export function setupIpc(mainWindow) {
     return r.canceled ? [] : r.filePaths;
   });
 
+  ipcMain.handle('cache:list', async () => listDownloadEntries());
+
   // 下載 YouTube 字幕（不抓影片）
   ipcMain.handle('ytdlp:fetchSubs', async (_e, { url, langs = 'zh-Hant,zh-Hans,zh-TW,zh,en.*' }) => {
     const { ytDlpPath } = getBinPaths();
     if (!ytDlpPath) throw new Error('yt-dlp 未設定');
     const cfg = getConfig();
     const cookiesPath = cfg.cookiesPath || '';
-    const outDir = path.join(os.tmpdir(), 'ytdlp_subs');
-    await fs.mkdir(outDir, { recursive: true });
+    const outDir = getSubsCacheDir();
+    await ensureDir(outDir);
+    const metaPrefix = '__meta__';
     const args = [
       ...(cookiesPath ? ['--cookies', cookiesPath] : []),
       '--write-subs',
       '--sub-langs', langs,
       '--skip-download',
       '--convert-subs', 'ass',
+      '--no-overwrites',
+      '--print', `${metaPrefix}id=%(id)s`,
+      '--print', `${metaPrefix}title=%(title)s`,
       '-o', path.join(outDir, '%(id)s.%(ext)s'),
       url
     ];
     const { out, err } = await run(ytDlpPath, args, { cwd: outDir });
-    // 找出 .ass
+    const combined = `${out}\n${err}`;
+    const meta = {};
+    combined.split(/\r?\n/).forEach((line) => {
+      if (!line) return;
+      if (!line.startsWith(metaPrefix)) return;
+      const rest = line.slice(metaPrefix.length);
+      const eq = rest.indexOf('=');
+      if (eq <= 0) return;
+      const key = rest.slice(0, eq);
+      const value = rest.slice(eq + 1);
+      meta[key] = value;
+    });
     const files = await fs.readdir(outDir);
-    const ass = files.filter(f => f.toLowerCase().endsWith('.ass'))
-      .map(f => path.join(outDir, f));
-    return { log: out + err, files: ass };
+    const assPaths = files
+      .filter(f => f.toLowerCase().endsWith('.ass'))
+      .map(f => path.join(outDir, f))
+      .filter((p) => {
+        if (!meta.id) return true;
+        const base = path.basename(p);
+        return base.startsWith(meta.id);
+      });
+    const entries = [];
+    for (const assPath of assPaths) {
+      const entry = await registerSubtitleDownload({ id: meta.id || path.parse(assPath).name, title: meta.title, sourcePath: assPath });
+      if (entry) entries.push(entry);
+    }
+    const normalizedFiles = entries.map((entry) => entry?.subsPath).filter(Boolean);
+    return { log: out + err, files: normalizedFiles.length ? normalizedFiles : assPaths, entries, meta };
   });
 
   // 轉字幕為 ASS
@@ -108,13 +278,14 @@ export function setupIpc(mainWindow) {
     const cookiesPath = cfg.cookiesPath || '';
 
     const jobId = `job_${Date.now()}_${++dlSeq}`;
-    const cacheDir = path.join(app.getPath('userData'), 'video-cache');
-    await fs.mkdir(cacheDir, { recursive: true });
+    const cacheDir = getVideoCacheDir();
+    await ensureDir(cacheDir);
 
     // 盡量拿到 h264+aac 的 mp4；取不到再交由 yt-dlp fallback
     const formatSel = "bv*[vcodec~='^(avc1|h264)']+ba/best";
 
     // 優先用 --print after_move:filepath 拿最終輸出路徑（舊版不支援會忽略）
+    const metaPrefix = '__meta__';
     const args = [
       ...(cookiesPath ? ['--cookies', cookiesPath] : []),
       '-f', formatSel,
@@ -122,6 +293,8 @@ export function setupIpc(mainWindow) {
       '--no-playlist',
       ...(ffmpegPath ? ['--ffmpeg-location', ffmpegPath] : []),
       '--output', path.join(cacheDir, '%(id)s.%(ext)s'),
+      '--print', `${metaPrefix}id=%(id)s`,
+      '--print', `${metaPrefix}title=%(title)s`,
       '--print', 'after_move:filepath',   // 新：合併/移動後的最終檔路徑
       url
     ];
@@ -132,35 +305,51 @@ export function setupIpc(mainWindow) {
     const send = (payload) => { try { e.sender.send('ytdlp:progress', payload); } catch { } };
 
     let finalFile = '';
+    let videoId = '';
+    let videoTitle = '';
     const reProg = /\[download\]\s+([\d.]+)%.*?at\s+([\d.]+\w+\/s).*?ETA\s+([\d:]+)/i;
     const reDest = /Destination:\s+(.+)\r?$/i;
     const reMerging = /\[Merger\]\s+Merging formats into\s+"(.+)"\r?$/i;
     const reExtractDst = /\[ExtractAudio\]\s+Destination:\s+(.+)\r?$/i;
 
-    const considerLine = (s, stream) => {
-      // 1) 進度
-      const mP = s.match(reProg);
-      if (mP) send({ jobId, type: 'progress', percent: Number(mP[1]), speed: mP[2], eta: mP[3] });
-
-      // 2) 可能的最終路徑（多重 fallback）
-      const m1 = s.match(reMerging) || s.match(reExtractDst) || s.match(reDest);
-      if (m1 && !finalFile) finalFile = m1[1];
-
-      // 3) --print after_move:filepath 輸出（整行就是最終路徑）
-      if (!finalFile && s.trim().length > 0) {
-        // 只要像是絕對路徑或 cacheDir 內的相對匹配就採用
-        const t = s.trim();
-        if (t.startsWith(cacheDir) || /^[A-Za-z]:\\/.test(t) || t.startsWith('/')) {
-          finalFile = t;
+    const considerChunk = (chunk, stream) => {
+      const text = chunk.toString();
+      text.split(/\r?\n/).forEach((lineRaw) => {
+        if (!lineRaw) return;
+        const trimmed = lineRaw.trim();
+        if (!trimmed) return;
+        if (trimmed.startsWith(metaPrefix)) {
+          const rest = trimmed.slice(metaPrefix.length);
+          const eq = rest.indexOf('=');
+          if (eq > 0) {
+            const key = rest.slice(0, eq);
+            const value = rest.slice(eq + 1);
+            if (key === 'id' && !videoId) videoId = value;
+            if (key === 'title' && !videoTitle) videoTitle = value;
+          }
+          return;
         }
-      }
 
-      // 4) 完整日誌
-      send({ jobId, type: 'log', stream, line: s });
+        const mP = lineRaw.match(reProg);
+        if (mP) {
+          send({ jobId, type: 'progress', percent: Number(mP[1]), speed: mP[2], eta: mP[3] });
+        }
+
+        const m1 = lineRaw.match(reMerging) || lineRaw.match(reExtractDst) || lineRaw.match(reDest);
+        if (m1 && !finalFile) finalFile = m1[1];
+
+        if (!finalFile && trimmed.length > 0) {
+          if (trimmed.startsWith(cacheDir) || /^[A-Za-z]:\\/.test(trimmed) || trimmed.startsWith('/')) {
+            finalFile = trimmed;
+          }
+        }
+
+        send({ jobId, type: 'log', stream, line: lineRaw });
+      });
     };
 
-    child.stdout.on('data', (d) => considerLine(d.toString(), 'stdout'));
-    child.stderr.on('data', (d) => considerLine(d.toString(), 'stderr'));
+    child.stdout.on('data', (d) => considerChunk(d, 'stdout'));
+    child.stderr.on('data', (d) => considerChunk(d, 'stderr'));
 
     child.on('close', async (code) => {
       running.delete(jobId);
@@ -179,7 +368,18 @@ export function setupIpc(mainWindow) {
           } catch { }
         }
         if (finalFile) {
-          send({ jobId, type: 'done', filename: path.basename(finalFile) });
+          const filename = path.basename(finalFile);
+          let entry = null;
+          try {
+            entry = await registerVideoDownload({
+              id: videoId || path.parse(filename).name,
+              title: videoTitle,
+              filename
+            });
+          } catch (err) {
+            console.error('[ytdlp:downloadVideo] registerVideoDownload failed', err);
+          }
+          send({ jobId, type: 'done', filename, entry });
         } else {
           send({ jobId, type: 'error', message: '下載完成但無法定位輸出檔案（可能為舊版 yt-dlp 異常輸出）' });
         }

--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -16,7 +16,9 @@ contextBridge.exposeInMainWorld('api', {
   readTextFile: (filePath) => ipcRenderer.invoke('file:readText', filePath),
   readBinaryBase64: (filePath) => ipcRenderer.invoke('file:readBinaryBase64', filePath),
   listCacheEntries: () => ipcRenderer.invoke('cache:list'),
+  importLocalToCache: (payload) => ipcRenderer.invoke('cache:importLocal', payload),
   ytdlpDownloadVideo: (payload) => ipcRenderer.invoke('ytdlp:downloadVideo', payload),
+  ytdlpDownloadAudio: (payload) => ipcRenderer.invoke('ytdlp:downloadAudio', payload),
   ytdlpCancel: (jobId) => ipcRenderer.invoke('ytdlp:cancel', { jobId }),
   onYtProgress: (cb) => ipcRenderer.on('ytdlp:progress', (_e, data) => cb?.(data)),
 

--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld('api', {
   notifyOverlay: (patch) => ipcRenderer.send('overlay:update', patch),
   readTextFile: (filePath) => ipcRenderer.invoke('file:readText', filePath),
   readBinaryBase64: (filePath) => ipcRenderer.invoke('file:readBinaryBase64', filePath),
+  listCacheEntries: () => ipcRenderer.invoke('cache:list'),
   ytdlpDownloadVideo: (payload) => ipcRenderer.invoke('ytdlp:downloadVideo', payload),
   ytdlpCancel: (jobId) => ipcRenderer.invoke('ytdlp:cancel', { jobId }),
   onYtProgress: (cb) => ipcRenderer.on('ytdlp:progress', (_e, data) => cb?.(data)),

--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -136,18 +136,14 @@ async function refreshCachedEntries({ activeVideoId = state.activeVideoId, activ
 
 
 function setupEventHandlers() {
-
   const debouncedSyncStyle = debounce(async () => {
     const style = collectStyle();
     await persistStyle(style);
     window.api.notifyOverlay({ style });
     syncOverlayConnection();
-    const activeEntry = state.cachedEntries.find((item) => item.id === state.activeVideoId && item.hasVideo && item.videoFilename);
-    if (!activeEntry) return;
-    // 重新設定下載影片的連線位置
-    const url = buildCacheUrl(activeEntry.videoFilename);
-    dom.video.src = url;
   }, 120);
+
+  
   dom.pickCookies?.addEventListener('click', handlePickCookies);
   dom.clearCookies?.addEventListener('click', handleClearCookies);
   dom.checkBins?.addEventListener('click', handleCheckBins);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -34,6 +34,7 @@
       <span id="binInfo" class="mono"></span>
     </div>
   </fieldset>
+  
   <fieldset>
   <legend>Cookies（Netscape cookies.txt）</legend>
   <div class="row">
@@ -68,11 +69,21 @@
       <span id="subsPicked" class="mono"></span>
     </div>
     <div class="row"><small>若非 .ass 會自動轉成 .ass。</small></div>
-  </fieldset>
-  
-  <fieldset>
-    <legend>yt-dlp 日誌</legend>
-    <pre id="ytLog" style="background:transparent; color:rgb(0, 0, 0); height:200px; overflow:auto; white-space:pre-wrap"></pre>
+
+    <details id="ytLogWrap" style="margin-top:8px">
+      <summary style="cursor:pointer; display:flex; align-items:center; gap:8px; user-select:none">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden style="transition:transform .15s">
+          <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>yt-dlp 日誌</span>
+      </summary>
+      <pre id="ytLog" style="background:transparent; color:rgb(0,0,0); height:200px; overflow:auto; white-space:pre-wrap; margin:8px 0 0 20px"></pre>
+    </details>
+    <style>
+      /* 讓小圖標在展開時旋轉，隱藏預設 marker */
+      #ytLogWrap[open] summary svg { transform: rotate(90deg); }
+      #ytLogWrap summary::-webkit-details-marker { display: none; }
+    </style></summary>
   </fieldset>
 
   <fieldset>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -52,6 +52,7 @@
       <label>YouTube 連結：</label>
       <input type="text" id="ytUrl" placeholder="https://www.youtube.com/watch?v=...">
       <button id="ytDownload" class="btn">下載影片</button>
+      <button id="ytDownloadAudio" class="btn">下載音訊</button>
       <button id="ytCancel" class="btn">取消下載</button>
       <button id="ytFetch" class="btn">僅下載字幕</button>
       <progress id="dlProg" max="100" value="0" style="display:none"></progress>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -51,15 +51,15 @@
     <div class="row">
       <label>YouTube 連結：</label>
       <input type="text" id="ytUrl" placeholder="https://www.youtube.com/watch?v=...">
-      <button id="ytDownload" class="btn">下載影片並播放</button>
+      <button id="ytDownload" class="btn">下載影片</button>
       <button id="ytCancel" class="btn">取消下載</button>
       <button id="ytFetch" class="btn">僅下載字幕</button>
       <progress id="dlProg" max="100" value="0" style="display:none"></progress>
       <span id="dlTxt" class="mono"></span>
     </div>
     <div class="row">
-      <label>本地影片：</label>
-      <input type="file" id="videoFile" accept="video/*">
+      <label>本地媒體：</label>
+      <input type="file" id="videoFile" accept="video/*,audio/*">
     </div>
     <div class="row">
       <label>本地字幕：</label>
@@ -117,6 +117,9 @@
   <fieldset>
     <legend>影片播放（同步 overlay 時間軸）</legend>
     <video id="localVideo" controls></video>
+    <div class="row">
+      <span id="activeCacheInfo" class="mono"></span>
+    </div>
   </fieldset>
 
   <script type="module" src="./app.mjs"></script>


### PR DESCRIPTION
## Summary
- track cached downloads in the main process, including subtitles and audio-only media, and expose them to the renderer
- update the renderer UI to list cached items with type labels, allow manual activation without autoplay, and show the selected media title
- allow local audio files to be picked and display cache status details in the panel

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc5f8523ec8328a5401e687d740467