### PR TITLE
Revamp control UI and add binary download progress

### DIFF
--- a/src/preload.cjs
+++ b/src/preload.cjs
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('api', {
   ytdlpDownloadAudio: (payload) => ipcRenderer.invoke('ytdlp:downloadAudio', payload),
   ytdlpCancel: (jobId) => ipcRenderer.invoke('ytdlp:cancel', { jobId }),
   onYtProgress: (cb) => ipcRenderer.on('ytdlp:progress', (_e, data) => cb?.(data)),
+  onBinProgress: (cb) => ipcRenderer.on('bins:progress', (_e, data) => cb?.(data)),
 
 
   // Subscribe to overlay state updates from main. Returns an unsubscribe fn.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -13,126 +13,746 @@
                  frame-src 'none'">
   <title>Subtitle Overlay</title>
   <style>
-    body { font: 14px/1.5 system-ui, "Noto Sans TC", sans-serif; margin: 20px; }
-    fieldset{margin-bottom:16px}
-    label{display:inline-block; min-width:120px}
-    input[type=text]{width:520px}
-    .row{margin:6px 0}
-    .btn{padding:6px 12px}
-    .mono{font-family: ui-monospace, SFMono-Regular, Consolas, monospace}
-    #localVideo { width: 720px; height: 405px; background:#111; display:block; }
-    progress { width: 320px; vertical-align: middle; }
+    :root {
+      color-scheme: light;
+      --bg-gradient: radial-gradient(circle at top left, rgba(59, 130, 246, 0.38), transparent 55%),
+                      radial-gradient(circle at 20% 80%, rgba(124, 58, 237, 0.32), transparent 55%),
+                      #0f172a;
+      --surface: rgba(255, 255, 255, 0.86);
+      --surface-soft: rgba(255, 255, 255, 0.72);
+      --text-primary: #0f172a;
+      --text-secondary: #475569;
+      --border: rgba(148, 163, 184, 0.45);
+      --accent: #2563eb;
+      --accent-strong: linear-gradient(135deg, #2563eb, #7c3aed);
+      --radius-lg: 24px;
+      --radius-md: 18px;
+      --radius-sm: 12px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font: 15px/1.6 "Inter", "Noto Sans TC", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--bg-gradient);
+      min-height: 100vh;
+      color: var(--text-primary);
+      display: flex;
+      justify-content: center;
+      padding: 36px 20px 64px;
+    }
+
+    body.sidebar-open {
+      overflow: hidden;
+    }
+
+    .app-shell {
+      position: relative;
+      width: min(1120px, 100%);
+      background: var(--surface);
+      backdrop-filter: blur(18px);
+      border-radius: var(--radius-lg);
+      box-shadow: 0 40px 80px -40px rgba(15, 23, 42, 0.45), 0 20px 40px -20px rgba(30, 64, 175, 0.25);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .topbar {
+      padding: 28px 32px 0;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 24px;
+    }
+
+    .brand {
+      display: flex;
+      gap: 18px;
+      align-items: center;
+    }
+
+    .brand-icon {
+      width: 52px;
+      height: 52px;
+      border-radius: 16px;
+      background: var(--accent-strong);
+      display: grid;
+      place-items: center;
+      color: #fff;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+    }
+
+    .brand h1 {
+      margin: 0;
+      font-size: 26px;
+      letter-spacing: 0.02em;
+    }
+
+    .brand p {
+      margin: 6px 0 0;
+      color: var(--text-secondary);
+      font-size: 14px;
+    }
+
+    .top-actions {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 20px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .bin-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      align-items: flex-start;
+      min-width: 260px;
+    }
+
+    .bin-progress {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      color: var(--text-secondary);
+      width: 100%;
+    }
+
+    .bin-progress.hidden {
+      display: none;
+    }
+
+    .bin-progress progress {
+      width: 200px;
+      height: 6px;
+      border-radius: 999px;
+    }
+
+    progress {
+      appearance: none;
+      border: none;
+      height: 6px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.3);
+    }
+
+    progress::-webkit-progress-bar {
+      background: rgba(148, 163, 184, 0.3);
+      border-radius: 999px;
+    }
+
+    progress::-webkit-progress-value {
+      background: var(--accent-strong);
+      border-radius: 999px;
+    }
+
+    progress::-moz-progress-bar {
+      background: var(--accent-strong);
+      border-radius: 999px;
+    }
+
+    .btn {
+      border: none;
+      border-radius: 999px;
+      padding: 10px 20px;
+      font-weight: 600;
+      font-size: 14px;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+      background: rgba(148, 163, 184, 0.25);
+      color: var(--text-primary);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+    }
+
+    .btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 22px -14px rgba(15, 23, 42, 0.35);
+    }
+
+    .btn.primary {
+      background: var(--accent-strong);
+      color: #fff;
+      box-shadow: 0 12px 24px -12px rgba(37, 99, 235, 0.65);
+    }
+
+    .btn.primary:hover {
+      box-shadow: 0 16px 28px -12px rgba(37, 99, 235, 0.7);
+    }
+
+    .btn.ghost {
+      background: transparent;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      color: var(--text-secondary);
+    }
+
+    .btn.subtle {
+      padding: 8px 14px;
+      background: transparent;
+      border: 1px solid transparent;
+      color: var(--text-secondary);
+    }
+
+    .btn.small {
+      padding: 6px 12px;
+      font-size: 13px;
+    }
+
+    .main-area {
+      padding: 0 32px 32px;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+
+    .card {
+      background: var(--surface-soft);
+      border-radius: var(--radius-md);
+      padding: 26px;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      box-shadow: 0 24px 36px -28px rgba(15, 23, 42, 0.45);
+    }
+
+    .card-header h2 {
+      margin: 0;
+      font-size: 22px;
+    }
+
+    .card-header p {
+      margin: 6px 0 0;
+      color: var(--text-secondary);
+      font-size: 14px;
+    }
+
+    .stack {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .row {
+      display: flex;
+      gap: 14px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .row label {
+      font-weight: 600;
+      min-width: 120px;
+      color: #1e293b;
+    }
+
+    .field-body {
+      flex: 1 1 240px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    input[type="text"],
+    input[type="number"],
+    input[type="search"],
+    select {
+      width: 100%;
+      padding: 10px 14px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: #fff;
+      color: var(--text-primary);
+      font: inherit;
+    }
+
+    input[type="file"] {
+      font: inherit;
+      color: var(--text-secondary);
+    }
+
+    .action-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .progress-row {
+      margin-left: 120px;
+    }
+
+    .progress-line {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text-secondary);
+      font-size: 13px;
+    }
+
+    #dlProg {
+      width: 220px;
+      display: none;
+    }
+
+    .hint {
+      margin: 0 0 0 120px;
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .preview-area {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    #localVideo {
+      width: 100%;
+      min-height: 320px;
+      border-radius: 16px;
+      background: #0f172a;
+      box-shadow: 0 18px 34px -24px rgba(15, 23, 42, 0.8);
+    }
+
+    .info-line {
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .apply-row {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      flex-wrap: wrap;
+    }
+
+    #applyMsg {
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .mono {
+      font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+    }
+
+    .muted {
+      color: var(--text-secondary);
+    }
+
+    /* Sidebar */
+    .sidebar-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.35);
+      backdrop-filter: blur(2px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.25s ease;
+      z-index: 40;
+    }
+
+    .sidebar-overlay.visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .sidebar {
+      position: fixed;
+      top: 0;
+      right: 0;
+      width: min(420px, 92vw);
+      height: 100vh;
+      background: rgba(15, 23, 42, 0.95);
+      color: #e2e8f0;
+      transform: translateX(100%);
+      transition: transform 0.3s ease;
+      z-index: 41;
+      display: flex;
+      flex-direction: column;
+      backdrop-filter: blur(12px);
+    }
+
+    .sidebar.open {
+      transform: translateX(0);
+    }
+
+    .sidebar-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 28px 28px 16px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .sidebar-header h2 {
+      margin: 0;
+      font-size: 20px;
+    }
+
+    .sidebar-content {
+      padding: 18px 28px 32px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .sidebar .row label,
+    .sidebar input,
+    .sidebar select,
+    .sidebar button {
+      color: #e2e8f0;
+    }
+
+    .sidebar input,
+    .sidebar select {
+      background: rgba(15, 23, 42, 0.65);
+      border: 1px solid rgba(148, 163, 184, 0.3);
+    }
+
+    .sidebar .btn {
+      color: #e2e8f0;
+    }
+
+    .accordion {
+      background: rgba(148, 163, 184, 0.08);
+      border-radius: 16px;
+      padding: 14px 18px;
+    }
+
+    .accordion > summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-weight: 600;
+      color: #cbd5f5;
+    }
+
+    .accordion > summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .accordion > summary span {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .accordion > summary svg {
+      transition: transform 0.2s ease;
+    }
+
+    .accordion[open] > summary svg {
+      transform: rotate(90deg);
+    }
+
+    .accordion-content {
+      margin-top: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      font-size: 14px;
+      color: #cbd5f5;
+    }
+
+    #ytLogWrap {
+      background: rgba(15, 23, 42, 0.72);
+      border-radius: 12px;
+      padding: 12px;
+    }
+
+    #ytLogWrap summary {
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #cbd5f5;
+    }
+
+    #ytLogWrap summary::-webkit-details-marker {
+      display: none;
+    }
+
+    #ytLogWrap[open] summary svg {
+      transform: rotate(90deg);
+    }
+
+    #ytLog {
+      margin: 10px 0 0;
+      max-height: 220px;
+      overflow: auto;
+      background: transparent;
+      color: #f8fafc;
+      font-size: 13px;
+      white-space: pre-wrap;
+    }
+
+    .sidebar small,
+    .sidebar .hint {
+      color: rgba(203, 213, 225, 0.82);
+    }
+
+    .sidebar .mono {
+      color: #e2e8f0;
+    }
+
+    @media (min-width: 980px) {
+      .main-area {
+        grid-template-columns: 1.4fr 1fr;
+      }
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 24px 12px 48px;
+      }
+
+      .app-shell {
+        border-radius: 20px;
+      }
+
+      .brand {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .topbar {
+        justify-content: center;
+      }
+
+      .progress-row,
+      .hint {
+        margin-left: 0;
+      }
+
+      .row {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .row label {
+        min-width: 0;
+      }
+
+      .apply-row {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      #localVideo {
+        min-height: 220px;
+      }
+    }
   </style>
 </head>
 <body>
-  <h2>Subtitle Overlay – 控制面板</h2>
+  <div class="app-shell">
+    <header class="topbar">
+      <div class="brand">
+        <div class="brand-icon">SO</div>
+        <div>
+          <h1>Subtitle Overlay</h1>
+          <p>控制面板</p>
+        </div>
+      </div>
+      <div class="top-actions">
+        <div class="bin-actions">
+          <button id="checkBins" class="btn primary">檢查 / 下載必要工具</button>
+          <span id="binInfo" class="mono muted">尚未檢查</span>
+          <div id="binProgressWrap" class="bin-progress hidden">
+            <progress id="binProgressBar" max="100"></progress>
+            <span id="binProgressLabel" class="mono"></span>
+          </div>
+        </div>
+        <button id="toggleAdvanced" class="btn ghost">進階設定</button>
+      </div>
+    </header>
 
-  <fieldset>
-    <legend>啟動檢查</legend>
-    <div class="row">
-      <button id="checkBins" class="btn">檢查/下載 yt-dlp / ffmpeg</button>
-      <span id="binInfo" class="mono"></span>
-    </div>
-  </fieldset>
-  
-  <fieldset>
-  <legend>Cookies（Netscape cookies.txt）</legend>
-  <div class="row">
-    <button id="pickCookies" class="btn">選擇 cookies.txt</button>
-    <button id="clearCookies" class="btn">清除</button>
-    <span id="cookiesView" class="mono"></span>
+    <main class="main-area">
+      <section class="card quick-card">
+        <header class="card-header">
+          <h2>快速開始</h2>
+          <p>輸入來源或載入本地檔案，立即預覽字幕與媒體。</p>
+        </header>
+        <div class="stack">
+          <div class="row">
+            <label for="ytUrl">YouTube 連結</label>
+            <div class="field-body">
+              <input type="text" id="ytUrl" placeholder="https://www.youtube.com/watch?v=...">
+              <div class="action-row">
+                <button id="ytDownload" class="btn primary">下載影片</button>
+                <button id="ytDownloadAudio" class="btn">下載音訊</button>
+                <button id="ytFetch" class="btn">僅下載字幕</button>
+                <button id="ytCancel" class="btn ghost small">取消</button>
+              </div>
+            </div>
+          </div>
+          <div class="row progress-row">
+            <label></label>
+            <div class="progress-line">
+              <progress id="dlProg" max="100" value="0" style="display:none"></progress>
+              <span id="dlTxt" class="mono"></span>
+            </div>
+          </div>
+          <div class="row">
+            <label for="videoFile">本地媒體</label>
+            <input type="file" id="videoFile" accept="video/*,audio/*">
+          </div>
+          <div class="row">
+            <label>本地字幕</label>
+            <div class="action-row">
+              <button id="pickSubs" class="btn">選擇字幕檔</button>
+              <span id="subsPicked" class="mono muted"></span>
+            </div>
+          </div>
+          <p class="hint">若非 .ass 會自動轉換。</p>
+        </div>
+      </section>
+
+      <section class="card preview-card">
+        <header class="card-header">
+          <h2>預覽與輸出</h2>
+          <p>確認字幕同步後，將設定套用到 overlay。</p>
+        </header>
+        <div class="preview-area">
+          <video id="localVideo" controls></video>
+          <div id="activeCacheInfo" class="info-line mono"></div>
+        </div>
+        <div class="apply-row">
+          <button id="applyToOverlay" class="btn primary">套用到 Overlay</button>
+          <span id="applyMsg"></span>
+        </div>
+      </section>
+    </main>
   </div>
-  <div class="row">
-    <small>若遇到 429 或需登入，請提供 cookies。如何匯出 YouTube cookies：<span class="mono">https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies</span></small>
-  </div>
-</fieldset>
 
-  <fieldset>
-    <legend>字幕來源</legend>
-    <div class="row">
-      <label>YouTube 連結：</label>
-      <input type="text" id="ytUrl" placeholder="https://www.youtube.com/watch?v=...">
-      <button id="ytDownload" class="btn">下載影片</button>
-      <button id="ytDownloadAudio" class="btn">下載音訊</button>
-      <button id="ytCancel" class="btn">取消下載</button>
-      <button id="ytFetch" class="btn">僅下載字幕</button>
-      <progress id="dlProg" max="100" value="0" style="display:none"></progress>
-      <span id="dlTxt" class="mono"></span>
+  <div id="sidebarOverlay" class="sidebar-overlay"></div>
+  <aside id="advancedSidebar" class="sidebar">
+    <div class="sidebar-header">
+      <h2>進階設定</h2>
+      <button id="closeAdvanced" class="btn ghost small">關閉</button>
     </div>
-    <div class="row">
-      <label>本地媒體：</label>
-      <input type="file" id="videoFile" accept="video/*,audio/*">
-    </div>
-    <div class="row">
-      <label>本地字幕：</label>
-      <button id="pickSubs" class="btn">選擇字幕檔</button>
-      <span id="subsPicked" class="mono"></span>
-    </div>
-    <div class="row"><small>若非 .ass 會自動轉成 .ass。</small></div>
+    <div class="sidebar-content">
+      <details class="accordion">
+        <summary>
+          <span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            Cookies（Netscape cookies.txt）
+          </span>
+        </summary>
+        <div class="accordion-content">
+          <div class="row">
+            <button id="pickCookies" class="btn">選擇 cookies.txt</button>
+            <button id="clearCookies" class="btn ghost small">清除</button>
+          </div>
+          <div id="cookiesView" class="mono">(未設定)</div>
+          <small>若遇到 429 或需登入，請提供 cookies。如何匯出 YouTube cookies：<span class="mono">https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies</span></small>
+        </div>
+      </details>
 
-    <details id="ytLogWrap" style="margin-top:8px">
-      <summary style="cursor:pointer; display:flex; align-items:center; gap:8px; user-select:none">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden style="transition:transform .15s">
-          <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-        <span>yt-dlp 日誌</span>
-      </summary>
-      <pre id="ytLog" style="background:transparent; color:rgb(0,0,0); height:200px; overflow:auto; white-space:pre-wrap; margin:8px 0 0 20px"></pre>
-    </details>
-    <style>
-      /* 讓小圖標在展開時旋轉，隱藏預設 marker */
-      #ytLogWrap[open] summary svg { transform: rotate(90deg); }
-      #ytLogWrap summary::-webkit-details-marker { display: none; }
-    </style></summary>
-  </fieldset>
+      <details class="accordion">
+        <summary>
+          <span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            字型管理
+          </span>
+        </summary>
+        <div class="accordion-content">
+          <div class="row">
+            <button id="pickFonts" class="btn">上傳字型</button>
+            <span id="fontsPicked" class="mono muted"></span>
+          </div>
+        </div>
+      </details>
 
-  <fieldset>
-    <legend>字型</legend>
-    <div class="row">
-      <label>上傳字型：</label>
-      <button id="pickFonts" class="btn">選擇 .ttf/.otf/.woff2</button>
-      <span id="fontsPicked" class="mono"></span>
-    </div>
-  </fieldset>
+      <details class="accordion">
+        <summary>
+          <span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            顯示樣式
+          </span>
+        </summary>
+        <div class="accordion-content">
+          <div class="row">
+            <label for="maxWidth">最大寬度(px)</label>
+            <input type="number" id="maxWidth" value="1920" min="320">
+          </div>
+          <div class="row">
+            <label for="align">對齊</label>
+            <select id="align">
+              <option value="left">置左</option>
+              <option value="center" selected>置中</option>
+              <option value="right">置右</option>
+            </select>
+          </div>
+          <div class="row">
+            <label for="background">背景</label>
+            <select id="background">
+              <option value="transparent" selected>透明</option>
+              <option value="green">綠幕</option>
+            </select>
+          </div>
+        </div>
+      </details>
 
-  <fieldset>
-    <legend>顯示樣式</legend>
-    <div class="row"><label>最大寬度(px)：</label><input type="number" id="maxWidth" value="1920"></div>
-    <div class="row"><label>對齊：</label>
-      <select id="align">
-        <option value="left">置左</option>
-        <option value="center" selected>置中</option>
-        <option value="right">置右</option>
-      </select>
-    </div>
-    <div class="row"><label>背景：</label>
-      <select id="background">
-        <option value="transparent" selected>透明</option>
-        <option value="green">綠幕</option>
-      </select>
-    </div>
-  </fieldset>
+      <details class="accordion">
+        <summary>
+          <span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            HTTP 輸出
+          </span>
+        </summary>
+        <div class="accordion-content">
+          <div class="row">
+            <label for="port">端口 (port)</label>
+            <input type="number" id="port" value="1976" min="1" max="65535">
+          </div>
+          <small>以 OBS Browser Source 指向 <span class="mono">http://localhost:<span id="portView">1976</span>/overlay</span></small>
+        </div>
+      </details>
 
-  <fieldset>
-    <legend>輸出（HTTP）</legend>
-    <div class="row">
-      <label>端口(port)：</label>
-      <input type="number" id="port" value="1976">
-      <span class="mono">  →  http://localhost:<span id="portView">1976</span>/overlay</span>
+      <details class="accordion">
+        <summary>
+          <span>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            下載記錄
+          </span>
+        </summary>
+        <div class="accordion-content">
+          <details id="ytLogWrap">
+            <summary>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path d="M8 5l8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span>yt-dlp 日誌</span>
+            </summary>
+            <pre id="ytLog"></pre>
+          </details>
+        </div>
+      </details>
     </div>
-    <div class="row">
-      <button id="applyToOverlay" class="btn">載入到輸出</button>
-      <span id="applyMsg"></span>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <legend>影片播放（同步 overlay 時間軸）</legend>
-    <video id="localVideo" controls></video>
-    <div class="row">
-      <span id="activeCacheInfo" class="mono"></span>
-    </div>
-  </fieldset>
+  </aside>
 
   <script type="module" src="./app.mjs"></script>
 </body>


### PR DESCRIPTION
## Summary
- redesign the renderer control panel with a modern quick-start layout and sidebar for advanced controls
- stream yt-dlp/ffmpeg download progress from the main process and display it in the renderer
- expose binary progress events through the preload bridge while keeping existing overlay workflows

## Testing
- not run (Electron app)


------
https://chatgpt.com/codex/tasks/task_e_68cd0bb38af483289f0826321826ad9b