### PR TITLE
feat: refresh quick start controls styling

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -130,6 +130,59 @@
       display: none;
     }
 
+    #binInfo {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      align-items: flex-start;
+    }
+
+    .bin-status-list {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .bin-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.18);
+      color: var(--text-secondary);
+      font-size: 13px;
+      letter-spacing: 0.01em;
+    }
+
+    .bin-status__icon {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      font-size: 11px;
+      font-weight: 700;
+      background: rgba(255, 255, 255, 0.9);
+      color: inherit;
+    }
+
+    .bin-status__label {
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+
+    .bin-status.ok {
+      background: rgba(34, 197, 94, 0.18);
+      color: #15803d;
+    }
+
+    .bin-status.missing {
+      background: rgba(248, 113, 113, 0.18);
+      color: #b91c1c;
+    }
+
     .bin-progress progress {
       width: 200px;
       height: 6px;
@@ -275,44 +328,102 @@
     }
 
 
-    select {
-      width: 100%;
-      padding: 10px 14px;
-      border-radius: 12px;
-      border: 1px solid var(--border);
-      background: #fff;
-      color: var(--text-primary);
-      font: inherit;
-      -webkit-appearance: none;
-      -moz-appearance: none;
-      appearance: none;
-
-      /* 預留右側空間，避免文字壓到箭頭 */
-      padding-right: 2.5em;
-      /* 依需要調整 */
-
-      /* 自訂箭頭（SVG，可改顏色與大小） */
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
-      background-repeat: no-repeat;
-
-      /* 這裡決定箭頭距右邊距離：改 12px 即可「往左移」 */
-      background-position: right 12px center;
-      background-size: 1em auto;
+    .file-input {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
 
-    /* 強制色彩模式下恢復原生，避免不可見 */
+    .select-control {
+      position: relative;
+      display: flex;
+      align-items: center;
+      width: 100%;
+      flex: 1 1 auto;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: #fff;
+      color: var(--text-secondary);
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+    }
+
+    .select-control select {
+      appearance: none;
+      background: transparent;
+      border: none;
+      padding: 10px 44px 10px 14px;
+      width: 100%;
+      font: inherit;
+      color: var(--text-primary);
+      outline: none;
+      cursor: pointer;
+    }
+
+    .select-control select:disabled {
+      cursor: not-allowed;
+      color: rgba(71, 85, 105, 0.6);
+    }
+
+    .select-control::after {
+      content: '';
+      position: absolute;
+      right: 16px;
+      width: 8px;
+      height: 8px;
+      border-right: 2px solid currentColor;
+      border-bottom: 2px solid currentColor;
+      transform: rotate(45deg);
+      pointer-events: none;
+      transition: transform 0.2s ease;
+    }
+
+    .select-control:focus-within {
+      border-color: rgba(37, 99, 235, 0.45);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+      color: var(--accent);
+    }
+
+    .select-control:focus-within::after {
+      transform: rotate(45deg) translateY(2px);
+    }
+
+    .sidebar .select-control {
+      background: rgba(15, 23, 42, 0.65);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      color: rgba(148, 163, 184, 0.8);
+    }
+
+    .sidebar .select-control select {
+      color: #e2e8f0;
+    }
+
+    .sidebar .select-control:focus-within {
+      border-color: rgba(96, 165, 250, 0.8);
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.28);
+      color: rgba(148, 197, 255, 0.95);
+    }
+
     @media (forced-colors: active) {
-      select {
+      .select-control {
+        border: 1px solid CanvasText;
+        background: Canvas;
+        color: CanvasText;
+      }
+
+      .select-control select {
         appearance: auto;
-        background-image: none;
         padding-right: 14px;
       }
-    }
 
-
-    input[type="file"] {
-      font: inherit;
-      color: var(--text-secondary);
+      .select-control::after {
+        display: none;
+      }
     }
 
     .action-row {
@@ -673,7 +784,11 @@
           </div>
           <div class="row">
             <label for="videoFile">本地媒體</label>
-            <input type="file" id="videoFile" accept="video/*,audio/*">
+            <div class="action-row">
+              <input type="file" id="videoFile" class="file-input" accept="video/*,audio/*">
+              <button id="pickMedia" class="btn" type="button">選擇媒體檔</button>
+              <span id="mediaPicked" class="mono muted"></span>
+            </div>
           </div>
           <div class="row">
             <label>本地字幕</label>
@@ -765,18 +880,22 @@
           </div>
           <div class="row">
             <label for="align">對齊</label>
-            <select id="align">
-              <option value="left">置左</option>
-              <option value="center" selected>置中</option>
-              <option value="right">置右</option>
-            </select>
+            <div class="select-control">
+              <select id="align">
+                <option value="left">置左</option>
+                <option value="center" selected>置中</option>
+                <option value="right">置右</option>
+              </select>
+            </div>
           </div>
           <div class="row">
             <label for="background">背景</label>
-            <select id="background">
-              <option value="transparent" selected>透明</option>
-              <option value="green">綠幕</option>
-            </select>
+            <div class="select-control">
+              <select id="background">
+                <option value="transparent" selected>透明</option>
+                <option value="green">綠幕</option>
+              </select>
+            </div>
           </div>
         </div>
       </details>


### PR DESCRIPTION
## Summary
- swap the local media picker for a styled button with matching status labels for media/subtitle selections
- restyle select inputs with a custom container and arrow to eliminate the border gap and align with the UI
- replace binary path text with check/close status chips beside the verification icon

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd5b15a40c83288e31de5779debb4a