### PR TITLE
Streamline picker styling and layout

### DIFF
--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -11,8 +11,8 @@ const dom = {
   dlTxt: $('#dlTxt'),
   video: $('#localVideo'),
   videoFile: $('#videoFile'),
+  pickVideo: $('#pickVideo'),
   ytUrl: $('#ytUrl'),
-  subsPicked: $('#subsPicked'),
   fontsPicked: $('#fontsPicked'),
   pickCookies: $('#pickCookies'),
   clearCookies: $('#clearCookies'),
@@ -34,21 +34,21 @@ const dom = {
   sidebarOverlay: $('#sidebarOverlay'),
   binProgressWrap: $('#binProgressWrap'),
   binProgressBar: $('#binProgressBar'),
-  binProgressLabel: $('#binProgressLabel')
+  binProgressLabel: $('#binProgressLabel'),
+  binStatusYt: $('#binStatusYtIcon'),
+  binStatusFfmpeg: $('#binStatusFfmpegIcon')
 };
 
 const videoCacheControls = createCacheSelector(dom.videoFile?.closest('.row'), {
   label: '快取媒體：',
-  searchPlaceholder: '搜尋影片或音訊...',
-  hint: '（快取的影片 / 音訊會列在此，可搜尋）'
+  searchPlaceholder: '搜尋影片或音訊...'
 });
 dom.videoCacheSelect = videoCacheControls?.select || null;
 dom.videoCacheSearch = videoCacheControls?.search || null;
 
 const subsCacheControls = createCacheSelector(dom.pickSubs?.closest('.row'), {
   label: '快取字幕：',
-  searchPlaceholder: '搜尋字幕...',
-  hint: '（快取的字幕會列在此，可搜尋）'
+  searchPlaceholder: '搜尋字幕...'
 });
 dom.subsCacheSelect = subsCacheControls?.select || null;
 dom.subsCacheSearch = subsCacheControls?.search || null;
@@ -128,7 +128,7 @@ async function loadInitialConfig() {
 async function loadBinInfo() {
   try {
     const bins = await window.api.getBins?.();
-    if (bins) setBinInfo(bins);
+    setBinInfo(bins || null);
   } catch (err) {
     console.error('[bins] 載入工具資訊失敗', err);
   }
@@ -147,6 +147,10 @@ async function refreshCachedEntries({ activeVideoId = state.activeVideoId, activ
     updateVideoCacheSelect(state.activeVideoId);
     updateSubsCacheSelect(state.activeSubsId);
     updateActiveCacheInfo({ video: videoEntry || null, subs: subsEntry || null });
+    if (videoEntry) await loadVideoEntry(videoEntry);
+    else setButtonSelection(dom.pickVideo, { selected: false });
+    if (subsEntry) await loadSubtitleEntry(subsEntry);
+    else setButtonSelection(dom.pickSubs, { selected: false });
   } catch (err) {
     console.error('[cache] 無法載入快取清單', err);
   }
@@ -166,6 +170,7 @@ function setupEventHandlers() {
   dom.pickCookies?.addEventListener('click', handlePickCookies);
   dom.clearCookies?.addEventListener('click', handleClearCookies);
   dom.checkBins?.addEventListener('click', handleCheckBins);
+  dom.pickVideo?.addEventListener('click', handlePickVideo);
   dom.pickSubs?.addEventListener('click', handlePickSubs);
   dom.pickFonts?.addEventListener('click', handlePickFonts);
   dom.ytFetch?.addEventListener('click', handleFetchSubsOnly);
@@ -197,6 +202,9 @@ function setupEventHandlers() {
   dom.portInput?.addEventListener('input', () => {
     dom.portView.textContent = dom.portInput.value || '';
   });
+
+  setButtonSelection(dom.pickVideo, { selected: false });
+  setButtonSelection(dom.pickSubs, { selected: false });
 
   dom.applyToOverlay?.addEventListener('click', async () => {
     const style = collectStyle();
@@ -618,6 +626,7 @@ function handleSubsCacheSelectChange() {
 async function loadVideoEntry(entry) {
   if (!entry || !entry.hasVideo || !entry.videoFilename) {
     releaseObjectUrl();
+    setButtonSelection(dom.pickVideo, { selected: false });
     return;
   }
   releaseObjectUrl();
@@ -625,16 +634,21 @@ async function loadVideoEntry(entry) {
   dom.video.src = url;
   dom.video.pause();
   try { dom.video.currentTime = 0; } catch { /* noop */ }
+  const label = getVideoEntryLabel(entry);
+  const tooltip = entry.videoPath || entry.videoFilename || '';
+  setButtonSelection(dom.pickVideo, { selected: true, label, tooltip });
   syncOverlayConnection();
 }
 
 async function loadSubtitleEntry(entry) {
   if (!entry || !entry.hasSubs || !entry.subsPath) {
+    setButtonSelection(dom.pickSubs, { selected: false });
     return;
   }
   try {
     await loadAssIntoOverlay(entry.subsPath);
-    if (dom.subsPicked) dom.subsPicked.textContent = entry.subsPath;
+    const label = getSubtitleEntryLabel(entry);
+    setButtonSelection(dom.pickSubs, { selected: true, label, tooltip: entry.subsPath });
   } catch (err) {
     console.error('[cache] 載入字幕失敗', err);
     alert('載入快取字幕失敗：' + (err?.message || err));
@@ -675,14 +689,22 @@ async function handleFetchSubsOnly() {
         updateSubsCacheSelect(firstSubs.id);
         await loadSubtitleEntry(firstSubs);
         updateActiveCacheInfo({ video: getEntryById(state.activeVideoId), subs: firstSubs });
-        dom.subsPicked.textContent = firstSubs.subsPath;
+        setButtonSelection(dom.pickSubs, {
+          selected: true,
+          label: getSubtitleEntryLabel(firstSubs),
+          tooltip: firstSubs.subsPath || ''
+        });
       } else {
         updateSubsCacheSelect(state.activeSubsId);
       }
     } else {
       const assPath = files.find((f) => f.toLowerCase().endsWith('.ass')) || files[0];
       await loadAssIntoOverlay(assPath);
-      dom.subsPicked.textContent = assPath;
+      setButtonSelection(dom.pickSubs, {
+        selected: true,
+        label: extractFileName(assPath),
+        tooltip: assPath || ''
+      });
       refreshCachedEntries().catch((err) => console.error('[cache] 重新整理快取失敗', err));
     }
   } catch (err) {
@@ -699,13 +721,22 @@ async function handlePickSubs() {
     try {
       const { outPath } = await window.api.convertToAss({ inputPath: path });
       path = outPath;
-      dom.subsPicked.textContent = `${path}（已轉 ASS）`;
+      const convertedName = extractFileName(path);
+      setButtonSelection(dom.pickSubs, {
+        selected: true,
+        label: convertedName ? `${convertedName}（已轉 ASS）` : '（已轉 ASS）',
+        tooltip: path || ''
+      });
     } catch (err) {
       alert('轉 ASS 失敗：' + (err?.message || err));
       return;
     }
   } else {
-    dom.subsPicked.textContent = path;
+    setButtonSelection(dom.pickSubs, {
+      selected: true,
+      label: extractFileName(path),
+      tooltip: path || ''
+    });
   }
   const subsTitle = stripFileExtension(path.split(/[\\/]/).pop() || '');
   const payload = { subsPath: path };
@@ -721,7 +752,11 @@ async function handlePickSubs() {
         updateSubsCacheSelect(merged.id);
         await loadSubtitleEntry(merged);
         updateActiveCacheInfo({ video: getEntryById(state.activeVideoId), subs: merged });
-        dom.subsPicked.textContent = merged.subsPath;
+        setButtonSelection(dom.pickSubs, {
+          selected: true,
+          label: getSubtitleEntryLabel(merged),
+          tooltip: merged.subsPath || ''
+        });
       } else {
         updateSubsCacheSelect(state.activeSubsId);
       }
@@ -732,7 +767,11 @@ async function handlePickSubs() {
     alert('匯入字幕失敗：' + (err?.message || err));
   }
 
-  dom.subsPicked.textContent = path;
+  setButtonSelection(dom.pickSubs, {
+    selected: true,
+    label: extractFileName(path),
+    tooltip: path || ''
+  });
   try {
     await loadAssIntoOverlay(path);
   } catch (err) {
@@ -774,6 +813,7 @@ async function handleCheckBins() {
       state.binProgress.clear();
       renderBinProgress();
     }
+    setBinInfo(null);
     const bins = await window.api.ensureBins();
     setBinInfo(bins);
   } catch (err) {
@@ -782,11 +822,44 @@ async function handleCheckBins() {
 }
 
 function setBinInfo(bins) {
-  if (!bins) return;
-  dom.binInfo.textContent = `yt-dlp: ${bins.ytDlpPath || '未設定'} | ffmpeg: ${bins.ffmpegPath || '未設定'}`;
+  applyBinStatus(dom.binStatusYt, {
+    available: Boolean(bins?.ytDlpPath),
+    pending: !bins,
+    tooltip: bins?.ytDlpPath || ''
+  });
+  applyBinStatus(dom.binStatusFfmpeg, {
+    available: Boolean(bins?.ffmpegPath),
+    pending: !bins,
+    tooltip: bins?.ffmpegPath || ''
+  });
+}
+
+function applyBinStatus(iconEl, { available = false, pending = false, tooltip = '' } = {}) {
+  if (!iconEl) return;
+  const wrapper = iconEl.closest('.bin-status-item');
+  if (wrapper) {
+    if (pending) wrapper.dataset.state = 'pending';
+    else wrapper.dataset.state = available ? 'ok' : 'fail';
+    if (tooltip) wrapper.setAttribute('title', tooltip);
+    else wrapper.removeAttribute('title');
+  }
+  if (pending) {
+    iconEl.textContent = '–';
+  } else if (available) {
+    iconEl.textContent = '✓';
+  } else {
+    iconEl.textContent = '✕';
+  }
 }
 
 /* ---------------- 本地影片 ---------------- */
+function handlePickVideo(event) {
+  event?.preventDefault();
+  if (!dom.videoFile) return;
+  try { dom.videoFile.value = ''; } catch { /* noop */ }
+  dom.videoFile.click();
+}
+
 async function handleLocalFileSelected(ev) {
   const file = ev.target.files?.[0];
   if (!file) return;
@@ -852,6 +925,11 @@ async function handleLocalFileSelected(ev) {
     dom.activeCacheInfo.textContent = `影片/音訊：本地媒體：${file.name} | 字幕：${subsLabel}`;
   }
   playVideo(url);
+  setButtonSelection(dom.pickVideo, {
+    selected: true,
+    label: file.name || '',
+    tooltip: filePath || file.name || ''
+  });
   ev.target.value = '';
 }
 
@@ -905,7 +983,7 @@ function debounce(fn, ms = 120) {
   };
 }
 
-function createCacheSelector(rowEl, { label, searchPlaceholder, hint } = {}) {
+function createCacheSelector(rowEl, { label, searchPlaceholder } = {}) {
   if (!rowEl || !rowEl.parentElement) return null;
   const container = document.createElement('div');
   container.className = 'row';
@@ -922,18 +1000,47 @@ function createCacheSelector(rowEl, { label, searchPlaceholder, hint } = {}) {
   select.style.minWidth = '260px';
   select.disabled = true;
   container.appendChild(select);
-  if (hint) {
-    const hintEl = document.createElement('small');
-    hintEl.style.marginLeft = '8px';
-    hintEl.textContent = hint;
-    container.appendChild(hintEl);
-  }
   const parent = rowEl.parentElement;
   if (parent) {
     if (rowEl.nextSibling) parent.insertBefore(container, rowEl.nextSibling);
     else parent.appendChild(container);
   }
   return { container, search: searchInput, select };
+}
+
+function extractFileName(path = '') {
+  if (!path) return '';
+  const normalized = String(path).split(/[\\/]/);
+  if (!normalized.length) return '';
+  return normalized[normalized.length - 1] || '';
+}
+
+function setButtonSelection(button, { selected = false, label = '', tooltip = '' } = {}) {
+  if (!button) return;
+  if (!button.dataset.baseLabel) {
+    button.dataset.baseLabel = button.textContent.trim();
+  }
+  if (selected) {
+    button.dataset.selected = 'true';
+    if (label) button.setAttribute('aria-label', `${button.dataset.baseLabel}，已選取 ${label}`);
+    else button.setAttribute('aria-label', `${button.dataset.baseLabel}，已選取`);
+  } else {
+    delete button.dataset.selected;
+    if (button.dataset.baseLabel) button.setAttribute('aria-label', button.dataset.baseLabel);
+    else button.removeAttribute('aria-label');
+  }
+  if (tooltip) button.title = tooltip;
+  else button.removeAttribute('title');
+}
+
+function getVideoEntryLabel(entry) {
+  if (!entry) return '';
+  return entry.title || entry.displayTitle || entry.videoFilename || extractFileName(entry.videoPath) || '';
+}
+
+function getSubtitleEntryLabel(entry) {
+  if (!entry) return '';
+  return entry.subsFilename || entry.title || entry.displayTitle || extractFileName(entry.subsPath) || '';
 }
 
 function stripFileExtension(name = '') {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -15,9 +15,6 @@
   <style>
     :root {
       color-scheme: light;
-      --bg-gradient: radial-gradient(circle at top left, rgba(59, 130, 246, 0.38), transparent 55%),
-        radial-gradient(circle at 20% 80%, rgba(124, 58, 237, 0.32), transparent 55%),
-        #0f172a;
       --surface: rgba(255, 255, 255, 0.86);
       --surface-soft: rgba(255, 255, 255, 0.72);
       --text-primary: #0f172a;
@@ -34,15 +31,21 @@
       box-sizing: border-box;
     }
 
+    html,
+    body {
+      height: 100%;
+    }
+
     body {
       margin: 0;
       font: 15px/1.6 "Inter", "Noto Sans TC", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: var(--bg-gradient);
+      background: var(--surface);
       min-height: 100vh;
       color: var(--text-primary);
       display: flex;
-      justify-content: center;
-      padding: 36px 20px 64px;
+      flex-direction: column;
+      align-items: stretch;
+      padding: 0;
     }
 
     body.sidebar-open {
@@ -51,11 +54,12 @@
 
     .app-shell {
       position: relative;
-      width: min(1120px, 100%);
+      width: 100%;
+      min-height: 100vh;
       background: var(--surface);
-      backdrop-filter: blur(18px);
-      border-radius: var(--radius-lg);
-      box-shadow: 0 40px 80px -40px rgba(15, 23, 42, 0.45), 0 20px 40px -20px rgba(30, 64, 175, 0.25);
+      backdrop-filter: none;
+      border-radius: 0;
+      box-shadow: none;
       overflow: hidden;
       display: flex;
       flex-direction: column;
@@ -112,9 +116,67 @@
     .bin-actions {
       display: flex;
       flex-direction: column;
-      gap: 10px;
+      gap: 12px;
       align-items: flex-start;
       min-width: 260px;
+    }
+
+    .bin-controls {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .bin-status {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      font-size: 13px;
+      color: var(--text-secondary);
+      align-items: center;
+    }
+
+    .bin-status-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.16);
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .bin-status-item[data-state="ok"] {
+      background: rgba(34, 197, 94, 0.18);
+      color: #15803d;
+    }
+
+    .bin-status-item[data-state="fail"] {
+      background: rgba(248, 113, 113, 0.18);
+      color: #b91c1c;
+    }
+
+    .bin-status-icon {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      font-size: 11px;
+      font-weight: 700;
+      background: rgba(148, 163, 184, 0.35);
+      color: var(--text-secondary);
+    }
+
+    .bin-status-item[data-state="ok"] .bin-status-icon {
+      background: rgba(34, 197, 94, 0.2);
+      color: #15803d;
+    }
+
+    .bin-status-item[data-state="fail"] .bin-status-icon {
+      background: rgba(248, 113, 113, 0.22);
+      color: #b91c1c;
     }
 
     .bin-progress {
@@ -178,6 +240,22 @@
     .btn:hover {
       transform: translateY(-1px);
       box-shadow: 0 14px 22px -14px rgba(15, 23, 42, 0.35);
+    }
+
+    .btn[data-selected="true"] {
+      position: relative;
+      padding-right: 42px;
+    }
+
+    .btn[data-selected="true"]::after {
+      content: '✓';
+      position: absolute;
+      right: 18px;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 14px;
+      font-weight: 600;
+      color: currentColor;
     }
 
     .btn.primary {
@@ -277,42 +355,51 @@
 
     select {
       width: 100%;
-      padding: 10px 14px;
-      border-radius: 12px;
-      border: 1px solid var(--border);
-      background: #fff;
-      color: var(--text-primary);
       font: inherit;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.55);
+      padding: 10px 46px 10px 18px;
+      background-color: rgba(255, 255, 255, 0.85);
+      color: var(--text-primary);
       -webkit-appearance: none;
       -moz-appearance: none;
       appearance: none;
-
-      /* 預留右側空間，避免文字壓到箭頭 */
-      padding-right: 2.5em;
-      /* 依需要調整 */
-
-      /* 自訂箭頭（SVG，可改顏色與大小） */
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+      background-image: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(124, 58, 237, 0.12)),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%231f2937' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
       background-repeat: no-repeat;
-
-      /* 這裡決定箭頭距右邊距離：改 12px 即可「往左移」 */
-      background-position: right 12px center;
-      background-size: 1em auto;
+      background-position: left top, right 16px center;
+      background-size: 100% 100%, 16px;
+      transition: border-color 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
     }
 
-    /* 強制色彩模式下恢復原生，避免不可見 */
+    select:focus {
+      outline: none;
+      border-color: rgba(37, 99, 235, 0.75);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      background-color: rgba(255, 255, 255, 0.95);
+    }
+
+    select:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      background-image: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.1)),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%2367748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+      background-position: left top, right 16px center;
+      background-size: 100% 100%, 16px;
+    }
+
     @media (forced-colors: active) {
       select {
         appearance: auto;
         background-image: none;
         padding-right: 14px;
+        border-radius: 12px;
       }
     }
 
 
-    input[type="file"] {
-      font: inherit;
-      color: var(--text-secondary);
+    #videoFile {
+      display: none;
     }
 
     .action-row {
@@ -634,8 +721,19 @@
       </div>
       <div class="top-actions">
         <div class="bin-actions">
-          <button id="checkBins" class="btn primary">檢查 / 下載必要工具</button>
-          <span id="binInfo" class="mono muted">尚未檢查</span>
+          <div class="bin-controls">
+            <button id="checkBins" class="btn primary">檢查 / 下載必要工具</button>
+            <div id="binInfo" class="bin-status">
+              <div class="bin-status-item" data-state="pending">
+                <span id="binStatusYtIcon" class="bin-status-icon" aria-hidden>–</span>
+                <span class="bin-status-text">yt-dlp</span>
+              </div>
+              <div class="bin-status-item" data-state="pending">
+                <span id="binStatusFfmpegIcon" class="bin-status-icon" aria-hidden>–</span>
+                <span class="bin-status-text">ffmpeg</span>
+              </div>
+            </div>
+          </div>
           <div id="binProgressWrap" class="bin-progress hidden">
             <progress id="binProgressBar" max="100"></progress>
             <span id="binProgressLabel" class="mono"></span>
@@ -672,14 +770,16 @@
             </div>
           </div>
           <div class="row">
-            <label for="videoFile">本地媒體</label>
-            <input type="file" id="videoFile" accept="video/*,audio/*">
+            <label for="pickVideo">本地媒體</label>
+            <div class="action-row">
+              <button id="pickVideo" class="btn" type="button">選擇媒體檔</button>
+            </div>
+            <input type="file" id="videoFile" accept="video/*,audio/*" hidden>
           </div>
           <div class="row">
             <label>本地字幕</label>
             <div class="action-row">
               <button id="pickSubs" class="btn">選擇字幕檔</button>
-              <span id="subsPicked" class="mono muted"></span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the window gradient padding so the app shell fills the frame and align the tool status controls in a horizontal row
- simplify the local media/subtitle pickers to button-only controls with visual selection indicators and drop the cache helper hint text
- update renderer logic to manage picker selection state on the buttons while keeping cache refreshes in sync with loaded entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd63524e908328a30183a33e93adf9