### PR TITLE
Add control panel minimization toggles and improve cache info display

### DIFF
--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -2,7 +2,9 @@ const $ = (selector) => document.querySelector(selector);
 
 const dom = {
   binInfo: $('#binInfo'),
+  mainArea: document.querySelector('.main-area'),
   controlCard: $('#controlCard'),
+  previewCard: $('#previewCard'),
   controlToggle: $('#controlCardToggle'),
   previewToggle: $('#previewCardToggle'),
   portInput: $('#port'),
@@ -66,7 +68,8 @@ const state = {
   subsSearch: '',
   objectUrl: '',
   binProgress: new Map(),
-  controlHidden: false
+  controlCollapsed: false,
+  previewCollapsed: false
 };
 
 /* ---------------- Overlay 時間同步 ---------------- */
@@ -107,6 +110,7 @@ const overlaySync = new OverlaySync(dom.video);
 (async function init() {
   setupEventHandlers();
   applyControlVisibility();
+  applyPreviewVisibility();
   await loadInitialConfig();
   await loadBinInfo();
   await refreshCachedEntries();
@@ -190,15 +194,17 @@ function setupEventHandlers() {
   });
 
   dom.controlToggle?.addEventListener('click', () => {
-    if (state.controlHidden) return;
-    setControlHidden(true);
-    dom.previewToggle?.focus();
+    const nextCollapsed = !state.controlCollapsed;
+    setControlCollapsed(nextCollapsed);
+    if (!nextCollapsed) {
+      dom.controlToggle?.focus();
+    }
   });
   dom.previewToggle?.addEventListener('click', () => {
-    const nextHidden = !state.controlHidden;
-    setControlHidden(nextHidden);
-    if (!nextHidden) {
-      dom.controlToggle?.focus();
+    const nextCollapsed = !state.previewCollapsed;
+    setPreviewCollapsed(nextCollapsed);
+    if (!nextCollapsed) {
+      dom.previewToggle?.focus();
     }
   });
 
@@ -228,29 +234,42 @@ function setupEventHandlers() {
   });
 }
 
-function setControlHidden(hidden) {
-  state.controlHidden = Boolean(hidden);
+function setControlCollapsed(collapsed) {
+  state.controlCollapsed = Boolean(collapsed);
   applyControlVisibility();
 }
 
+function setPreviewCollapsed(collapsed) {
+  state.previewCollapsed = Boolean(collapsed);
+  applyPreviewVisibility();
+}
+
 function applyControlVisibility() {
+  const collapsed = state.controlCollapsed;
   const minimizeLabel = '最小化控制區';
   const restoreLabel = '顯示控制區';
-  if (dom.controlCard) {
-    dom.controlCard.classList.toggle('card-collapsed', state.controlHidden);
-  }
+  dom.controlCard?.classList.toggle('card-collapsed', collapsed);
+  dom.mainArea?.classList.toggle('controls-collapsed', collapsed);
   if (dom.controlToggle) {
-    dom.controlToggle.textContent = minimizeLabel;
-    dom.controlToggle.setAttribute('aria-label', minimizeLabel);
+    const label = collapsed ? restoreLabel : minimizeLabel;
+    dom.controlToggle.textContent = label;
+    dom.controlToggle.setAttribute('aria-label', label);
     dom.controlToggle.setAttribute('aria-controls', 'controlCard');
-    dom.controlToggle.setAttribute('aria-expanded', String(!state.controlHidden));
+    dom.controlToggle.setAttribute('aria-expanded', String(!collapsed));
   }
+}
+
+function applyPreviewVisibility() {
+  const collapsed = state.previewCollapsed;
+  const minimizeLabel = '最小化預覽與輸出';
+  const restoreLabel = '顯示預覽與輸出';
+  dom.previewCard?.classList.toggle('card-collapsed', collapsed);
   if (dom.previewToggle) {
-    const label = state.controlHidden ? restoreLabel : minimizeLabel;
+    const label = collapsed ? restoreLabel : minimizeLabel;
     dom.previewToggle.textContent = label;
     dom.previewToggle.setAttribute('aria-label', label);
-    dom.previewToggle.setAttribute('aria-controls', 'controlCard');
-    dom.previewToggle.setAttribute('aria-expanded', String(!state.controlHidden));
+    dom.previewToggle.setAttribute('aria-controls', 'previewCard');
+    dom.previewToggle.setAttribute('aria-expanded', String(!collapsed));
   }
 }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -283,13 +283,39 @@
       box-shadow: 0 24px 36px -28px rgba(15, 23, 42, 0.45);
     }
 
+    .card.card-collapsed {
+      display: none;
+    }
+
+    .card-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .card-header-text {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      flex: 1 1 auto;
+    }
+
+    .card-header-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+
     .card-header h2 {
       margin: 0;
       font-size: 22px;
     }
 
     .card-header p {
-      margin: 6px 0 0;
+      margin: 0;
       color: var(--text-secondary);
       font-size: 14px;
     }
@@ -430,6 +456,7 @@
     .info-line {
       font-size: 13px;
       color: var(--text-secondary);
+      white-space: pre-line;
     }
 
     .apply-row {
@@ -734,10 +761,15 @@
     </header>
 
     <main class="main-area">
-      <section class="card quick-card">
+      <section id="controlCard" class="card quick-card">
         <header class="card-header">
-          <h2>控制區</h2>
-          <p>載入字幕，並提供影片或音訊進行同步監聽或監看。<br>快速於OBS、streamlabs等軟體動態呈現！</p>
+          <div class="card-header-text">
+            <h2>控制區</h2>
+            <p>載入字幕，並提供影片或音訊進行同步監聽或監看。<br>快速於OBS、streamlabs等軟體動態呈現！</p>
+          </div>
+          <div class="card-header-actions">
+            <button id="controlCardToggle" class="btn ghost small" type="button">最小化控制區</button>
+          </div>
         </header>
         <div class="stack">
           <div class="row">
@@ -772,10 +804,15 @@
         </div>
       </section>
 
-      <section class="card preview-card">
+      <section id="previewCard" class="card preview-card">
         <header class="card-header">
-          <h2>預覽與輸出</h2>
-          <p>確認字幕同步後，將設定套用到 overlay。</p>
+          <div class="card-header-text">
+            <h2>預覽與輸出</h2>
+            <p>確認字幕同步後，將設定套用到 overlay。</p>
+          </div>
+          <div class="card-header-actions">
+            <button id="previewCardToggle" class="btn ghost small" type="button">最小化控制區</button>
+          </div>
         </header>
         <div class="preview-area">
           <video id="localVideo" controls></video>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -273,6 +273,10 @@
       gap: 24px;
     }
 
+    .main-area.controls-collapsed {
+      grid-template-columns: 1fr;
+    }
+
     .card {
       background: var(--surface-soft);
       border-radius: var(--radius-md);
@@ -284,7 +288,17 @@
     }
 
     .card.card-collapsed {
+      gap: 0;
+    }
+
+    .card.card-collapsed .card-body {
       display: none;
+    }
+
+    .card-body {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
     }
 
     .card-header {
@@ -681,6 +695,10 @@
       .main-area {
         grid-template-columns: 1.4fr 1fr;
       }
+
+      .main-area.controls-collapsed {
+        grid-template-columns: 1fr;
+      }
     }
 
     @media (max-width: 768px) {
@@ -771,7 +789,7 @@
             <button id="controlCardToggle" class="btn ghost small" type="button">最小化控制區</button>
           </div>
         </header>
-        <div class="stack">
+        <div class="stack card-body">
           <div class="row">
             <div class="field-body">
               <input type="text" id="ytUrl" placeholder="https://www.youtube.com/watch?v=...">
@@ -811,16 +829,18 @@
             <p>確認字幕同步後，將設定套用到 overlay。</p>
           </div>
           <div class="card-header-actions">
-            <button id="previewCardToggle" class="btn ghost small" type="button">最小化控制區</button>
+            <button id="previewCardToggle" class="btn ghost small" type="button">最小化預覽與輸出</button>
           </div>
         </header>
-        <div class="preview-area">
-          <video id="localVideo" controls></video>
-          <div id="activeCacheInfo" class="info-line mono"></div>
-        </div>
-        <div class="apply-row">
-          <button id="applyToOverlay" class="btn primary">套用到 Overlay</button>
-          <span id="applyMsg"></span>
+        <div class="card-body">
+          <div class="preview-area">
+            <video id="localVideo" controls></video>
+            <div id="activeCacheInfo" class="info-line mono"></div>
+          </div>
+          <div class="apply-row">
+            <button id="applyToOverlay" class="btn primary">套用到 Overlay</button>
+            <span id="applyMsg"></span>
+          </div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add header action buttons in control and preview cards to hide or restore the control panel
- manage the new toggle state in the renderer script and keep focus accessible when collapsing controls
- show cached media information on separate lines for easier reading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd83ac17108328a316302adaee0a26