### PR TITLE
Ensure force-default font strips ASS overrides

### DIFF
--- a/src/main/assUtils.mjs
+++ b/src/main/assUtils.mjs
@@ -3,6 +3,7 @@ import assStringify from 'ass-stringify';
 
 const ALIGN_OVERRIDE_TAG_REGEX = /\\{\\\\an\\d\\}/gi;
 const FONT_OVERRIDE_TAG_REGEX = /\\fn([^\\}]*?)(?=\\|}|$)/gi;
+const FONT_OVERRIDE_COMMAND_REGEX = /\\fn[^\\})]*?(?=[\\})]|$)/gi;
 const STYLE_SECTION_NAMES = new Set(['V4 Styles', 'V4+ Styles']);
 export const DEFAULT_PLAY_RES = Object.freeze({ x: 1920, y: 1080 });
 const ALIGN_KEY_TO_CODE = {
@@ -163,6 +164,7 @@ function rewriteAlignment(ast, alignCode, { forceDefaultFont = false, defaultFon
   }
 
   const shouldApplyAlign = Number.isFinite(alignCode);
+  const shouldStripFontOverrides = Boolean(forceDefaultFont && defaultFontFamily);
 
   for (const section of ast) {
     const sectionName = String(section?.section || '').trim();
@@ -209,7 +211,7 @@ function rewriteAlignment(ast, alignCode, { forceDefaultFont = false, defaultFon
       continue;
     }
 
-    if (!shouldApplyAlign) continue;
+    if (!shouldApplyAlign && !shouldStripFontOverrides) continue;
 
     if (String(sectionName).toLowerCase() === 'events') {
       for (const descriptor of section.body || []) {
@@ -219,13 +221,26 @@ function rewriteAlignment(ast, alignCode, { forceDefaultFont = false, defaultFon
         const styleName = typeof value.Style === 'string' ? value.Style.trim() : '';
         if (styleName && styleName !== 'Default') continue;
         if (typeof value.Text !== 'string') {
-          overridesRemaining = true;
+          if (shouldApplyAlign) overridesRemaining = true;
           continue;
         }
-        const cleaned = value.Text.replace(ALIGN_OVERRIDE_TAG_REGEX, '');
-        if (cleaned !== value.Text) {
-          value.Text = cleaned;
-          overridesRemoved += 1;
+
+        if (shouldApplyAlign) {
+          const cleaned = value.Text.replace(ALIGN_OVERRIDE_TAG_REGEX, '');
+          if (cleaned !== value.Text) {
+            value.Text = cleaned;
+            overridesRemoved += 1;
+          }
+        }
+
+        if (shouldStripFontOverrides && /\\fn/i.test(value.Text)) {
+          const withoutFontOverrides = value.Text.replace(FONT_OVERRIDE_COMMAND_REGEX, '');
+          const normalized = withoutFontOverrides.replace(/\{\s*\}/g, '');
+          if (normalized !== value.Text) {
+            value.Text = normalized;
+            overridesRemoved += 1;
+            defaultFontUpdated = true;
+          }
         }
       }
     }

--- a/src/main/config.mjs
+++ b/src/main/config.mjs
@@ -12,6 +12,8 @@ export const store = new Store({
       maxHeight: 1080,
       align: 'off',
       wrapStyle: 2,
+      defaultFontFamily: 'Noto Sans CJK SC',
+      forceDefaultFont: false,
       subtitleOffsetMode: 'advance',
       subtitleOffsetSeconds: 0,
       subtitleOffsetDefaults: {
@@ -26,7 +28,9 @@ export const store = new Store({
     // 新增：cookies 路徑（Netscape cookies.txt）
     cookiesPath: '',
     downloads: [],
-    fonts: []
+    fonts: [
+      { name: 'NotoSans-Regular.woff2', url: '/assets/fonts/NotoSans-Regular.woff2' }
+    ]
   }
 });
 

--- a/src/main/overlayServer.mjs
+++ b/src/main/overlayServer.mjs
@@ -11,7 +11,11 @@ const fontManager = fontManagerModule?.default ?? fontManagerModule;
 const FONT_LOOKUP_AVAILABLE = Boolean(fontManager?.findFontsSync);
 
 const WS_READY_STATE_OPEN = 1;
-const EMPTY_ASS_META = Object.freeze({ alignmentApplied: false, styleUpdated: false, overridesRemoved: 0 });
+const EMPTY_ASS_META = Object.freeze({ alignmentApplied: false, styleUpdated: false, overridesRemoved: 0, defaultFontReplaced: false });
+
+const DEFAULT_FONT_NAME = 'NotoSans-Regular.woff2';
+const DEFAULT_FONT_URL = '/assets/fonts/NotoSans-Regular.woff2';
+const DEFAULT_FONT_FAMILY = 'Noto Sans CJK SC';
 
 const FONT_WEIGHT_PATTERNS = [
   { regex: /\bextra[- ]?(thin|light)\b/gi, weight: 200 },
@@ -35,7 +39,15 @@ const FONT_ITALIC_PATTERNS = [/\bitalic\b/gi, /\boblique\b/gi];
 function mergeStyles(currentStyle, patchStyle) {
   const base = (currentStyle && typeof currentStyle === 'object') ? currentStyle : {};
   const patch = (patchStyle && typeof patchStyle === 'object') ? patchStyle : {};
-  return { ...base, ...patch };
+  const merged = { ...base, ...patch };
+  const normalizedFamily = typeof merged.defaultFontFamily === 'string' ? merged.defaultFontFamily.trim() : '';
+  merged.defaultFontFamily = normalizedFamily || DEFAULT_FONT_FAMILY;
+  if (typeof patch.forceDefaultFont === 'boolean') {
+    merged.forceDefaultFont = patch.forceDefaultFont;
+  } else if (typeof merged.forceDefaultFont !== 'boolean') {
+    merged.forceDefaultFont = Boolean(merged.forceDefaultFont);
+  }
+  return merged;
 }
 
 function clonePlayRes(playRes = DEFAULT_PLAY_RES) {
@@ -52,8 +64,35 @@ function normalizeFontBuffer(font) {
 }
 
 function normalizeFontBufferList(list) {
-  if (!Array.isArray(list)) return [];
-  return list.map(normalizeFontBuffer).filter(Boolean);
+  const input = Array.isArray(list) ? list : [];
+  const sanitized = [];
+  for (const font of input) {
+    const normalized = normalizeFontBuffer(font);
+    if (!normalized) continue;
+    if (isDefaultFontEntry(normalized)) continue;
+    sanitized.push(normalized);
+  }
+  return [createDefaultFontEntry(), ...sanitized];
+}
+
+function createDefaultFontEntry() {
+  return { name: DEFAULT_FONT_NAME, url: DEFAULT_FONT_URL };
+}
+
+function isDefaultFontEntry(font) {
+  if (!font || typeof font !== 'object') return false;
+  const url = typeof font.url === 'string' ? font.url : '';
+  const name = typeof font.name === 'string' ? font.name : '';
+  const lowerUrl = url ? url.toLowerCase() : '';
+  const lowerName = name ? name.toLowerCase() : '';
+  if (lowerUrl && lowerUrl.endsWith(DEFAULT_FONT_NAME.toLowerCase())) return true;
+  if (lowerName) {
+    if (lowerName === DEFAULT_FONT_NAME.toLowerCase()) return true;
+    if (lowerName === DEFAULT_FONT_FAMILY.toLowerCase()) return true;
+    const trimmed = lowerName.replace(/\.[^.]+$/, '');
+    if (trimmed === DEFAULT_FONT_NAME.replace(/\.[^.]+$/, '').toLowerCase()) return true;
+  }
+  return false;
 }
 
 function analyseFontName(name) {
@@ -341,7 +380,12 @@ export class OverlayServer {
     let fontNames = [];
 
     if (rawSub) {
-      const result = processAssForOverlay({ assText: rawSub, alignKey: mergedStyle?.align });
+      const result = processAssForOverlay({
+        assText: rawSub,
+        alignKey: mergedStyle?.align,
+        defaultFontFamily: mergedStyle?.defaultFontFamily || DEFAULT_FONT_FAMILY,
+        forceDefaultFont: mergedStyle?.forceDefaultFont
+      });
       processed = result.text ?? '';
       playRes = result.playRes ? clonePlayRes(result.playRes) : clonePlayRes();
       fontNames = Array.isArray(result.fontNames) ? result.fontNames : [];
@@ -349,7 +393,8 @@ export class OverlayServer {
         alignmentApplied: Boolean(result.alignmentApplied),
         styleUpdated: Boolean(result.styleUpdated),
         overridesRemoved: Number.isFinite(result.overridesRemoved) ? result.overridesRemoved : 0,
-        fontNames
+        fontNames,
+        defaultFontReplaced: Boolean(result.defaultFontReplaced)
       };
     } else {
       this.lastFontKey = '';

--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -25,6 +25,7 @@ const dom = {
   checkBins: $('#checkBins'),
   pickSubs: $('#pickSubs'),
   pickFonts: $('#pickFonts'),
+  clearFonts: $('#clearFonts'),
   ytDownload: $('#ytDownload'),
   ytDownloadAudio: $('#ytDownloadAudio'),
   ytCancel: $('#ytCancel'),
@@ -33,6 +34,7 @@ const dom = {
   align: $('#align'),
   maxWidth: $('#maxWidth'),
   maxHeight: $('#maxHeight'),
+  forceDefaultFont: $('#forceDefaultFont'),
   subtitleOffsetToggle: $('#subtitleOffsetToggle'),
   subtitleOffsetSeconds: $('#subtitleOffsetSeconds'),
   applyToOverlay: $('#applyToOverlay'),
@@ -61,6 +63,10 @@ const subsCacheControls = createCacheSelector(dom.pickSubs?.closest('.row'), {
 dom.subsCacheSelect = subsCacheControls?.select || null;
 dom.subsCacheSearch = subsCacheControls?.search || null;
 
+const DEFAULT_FONT_NAME = 'NotoSans-Regular.woff2';
+const DEFAULT_FONT_URL = '/assets/fonts/NotoSans-Regular.woff2';
+const DEFAULT_FONT_FAMILY = 'Noto Sans CJK SC';
+
 const state = {
   currentAssText: '',
   currentFonts: [],
@@ -83,7 +89,9 @@ const state = {
   subtitleOffsetSeconds: 0,
   subtitleOffsetDefaults: { mode: 'advance', seconds: 0 },
   subtitleOffsetOverrides: {},
-  overlayRefreshSeq: 0
+  overlayRefreshSeq: 0,
+  forceDefaultFont: false,
+  defaultFontFamily: DEFAULT_FONT_FAMILY
 };
 
 const ALIGN_OPTIONS = new Set([
@@ -186,8 +194,46 @@ function normalizeFontBuffer(font) {
   return normalized.data || normalized.url ? normalized : null;
 }
 
+function createDefaultFontEntry() {
+  return { name: DEFAULT_FONT_NAME, url: DEFAULT_FONT_URL };
+}
+
+function isDefaultFontEntry(font) {
+  if (!font || typeof font !== 'object') return false;
+  const url = typeof font.url === 'string' ? font.url : '';
+  const name = typeof font.name === 'string' ? font.name : '';
+  const lowerName = name ? name.toLowerCase() : '';
+  const lowerUrl = url ? url.toLowerCase() : '';
+  if (lowerUrl && lowerUrl.endsWith(DEFAULT_FONT_NAME.toLowerCase())) return true;
+  if (lowerName) {
+    if (lowerName === DEFAULT_FONT_NAME.toLowerCase()) return true;
+    if (lowerName === DEFAULT_FONT_FAMILY.toLowerCase()) return true;
+    const trimmed = lowerName.replace(/\.[^.]+$/, '');
+    if (trimmed === DEFAULT_FONT_NAME.replace(/\.[^.]+$/, '').toLowerCase()) return true;
+  }
+  return false;
+}
+
+function ensureDefaultFont(fonts = []) {
+  const list = Array.isArray(fonts) ? fonts : [];
+  const sanitized = [];
+  for (const font of list) {
+    const normalized = normalizeFontBuffer(font);
+    if (!normalized) continue;
+    if (isDefaultFontEntry(normalized)) continue;
+    sanitized.push(normalized);
+  }
+  return [createDefaultFontEntry(), ...sanitized];
+}
+
+function setCurrentFonts(fonts) {
+  state.currentFonts = ensureDefaultFont(fonts);
+  updateFontsLabel();
+}
+
 function describeFontName(font) {
   if (!font || typeof font !== 'object') return '';
+  if (isDefaultFontEntry(font)) return '';
   if (typeof font.name === 'string' && font.name) return font.name;
   if (typeof font.url === 'string' && font.url) {
     const parts = font.url.split(/[\\/]/);
@@ -405,10 +451,13 @@ async function syncSubtitleOffset({ mode = null, seconds = null, refresh = false
 
 async function loadInitialConfig() {
   const cfg = await window.api.getConfig();
-  const storedFonts = Array.isArray(cfg?.fonts) ? cfg.fonts.map(normalizeFontBuffer).filter(Boolean) : [];
-  state.currentFonts = storedFonts;
-  updateFontsLabel(storedFonts);
+  const storedFonts = Array.isArray(cfg?.fonts) ? cfg.fonts : [];
+  setCurrentFonts(storedFonts);
   const output = cfg?.output || {};
+  const defaultFontFamilyRaw = typeof output?.defaultFontFamily === 'string' ? output.defaultFontFamily.trim() : '';
+  state.defaultFontFamily = defaultFontFamilyRaw || DEFAULT_FONT_FAMILY;
+  state.forceDefaultFont = Boolean(output?.forceDefaultFont);
+  if (dom.forceDefaultFont) dom.forceDefaultFont.checked = state.forceDefaultFont;
   if (output.port != null) dom.portInput.value = String(output.port);
   if (output.maxWidth != null) dom.maxWidth.value = String(output.maxWidth);
   if (output.maxHeight != null) dom.maxHeight.value = String(output.maxHeight);
@@ -546,6 +595,8 @@ function setupEventHandlers() {
   dom.pickVideo?.addEventListener('click', handlePickVideo);
   dom.pickSubs?.addEventListener('click', handlePickSubs);
   dom.pickFonts?.addEventListener('click', handlePickFonts);
+  dom.clearFonts?.addEventListener('click', handleClearFonts);
+  dom.forceDefaultFont?.addEventListener('change', handleForceDefaultFontChange);
   dom.ytFetch?.addEventListener('click', handleFetchSubsOnly);
   dom.ytDownload?.addEventListener('click', handleDownloadVideo);
   dom.ytDownloadAudio?.addEventListener('click', handleDownloadAudio);
@@ -1463,15 +1514,29 @@ async function loadAssIntoOverlay(assPath) {
 async function handlePickFonts() {
   const files = await window.api.openFiles({ filters: [{ name: 'Fonts', extensions: ['ttf', 'otf', 'woff2', 'woff'] }] });
   if (!files.length) return;
-  state.currentFonts = [];
+  const pickedFonts = [];
   for (const filePath of files) {
     const base64 = await window.api.readBinaryBase64(filePath);
     const name = filePath.split(/[\\/]/).pop();
-    state.currentFonts.push({ name, data: base64 });
+    pickedFonts.push({ name, data: base64 });
   }
-  updateFontsLabel();
+  setCurrentFonts(pickedFonts);
   const style = collectStyle();
   await persistFonts(state.currentFonts);
+  await persistStyle(style);
+  window.api.notifyOverlay({ style, fontBuffers: state.currentFonts });
+}
+
+async function handleClearFonts() {
+  setCurrentFonts([]);
+  const style = collectStyle();
+  await persistFonts(state.currentFonts);
+  await persistStyle(style);
+  window.api.notifyOverlay({ style, fontBuffers: state.currentFonts });
+}
+
+async function handleForceDefaultFontChange() {
+  const style = collectStyle();
   await persistStyle(style);
   window.api.notifyOverlay({ style, fontBuffers: state.currentFonts });
 }
@@ -1652,6 +1717,12 @@ function collectStyle() {
   state.subtitleOffsetMode = mode;
   state.subtitleOffsetSeconds = seconds;
 
+  const forceDefaultFont = Boolean(dom.forceDefaultFont?.checked);
+  state.forceDefaultFont = forceDefaultFont;
+  const normalizedFamily = typeof state.defaultFontFamily === 'string' ? state.defaultFontFamily.trim() : '';
+  const defaultFontFamily = normalizedFamily || DEFAULT_FONT_FAMILY;
+  state.defaultFontFamily = defaultFontFamily;
+
   const defaults = {
     mode: normalizeSubtitleOffsetMode(state.subtitleOffsetDefaults?.mode),
     seconds: sanitizeSubtitleOffsetSeconds(state.subtitleOffsetDefaults?.seconds)
@@ -1667,6 +1738,8 @@ function collectStyle() {
     maxWidth: normalizeDimension(dom.maxWidth?.value, 1920),
     maxHeight: normalizeDimension(dom.maxHeight?.value, 1080),
     align: normalizeAlignValue(dom.align?.value),
+    defaultFontFamily,
+    forceDefaultFont,
     subtitleOffsetMode: mode,
     subtitleOffsetSeconds: seconds,
     subtitleOffsetDefaults: defaults,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1087,6 +1087,15 @@
         <div class="accordion-content">
           <div class="row">
             <button id="pickFonts" class="btn">上傳字型</button>
+            <button id="clearFonts" class="btn ghost small">清除</button>
+          </div>
+          <div class="row">
+            <label>
+              <input type="checkbox" id="forceDefaultFont">
+              強制覆蓋 Default 樣式字型
+            </label>
+          </div>
+          <div class="row">
             <span id="fontsPicked" class="mono muted"></span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- strip inline \fn font overrides when the force-default option is enabled so Default style subtitles pick up the saved Noto Sans font
- keep the bundled NotoSans-Regular.woff2 from appearing in the font picker summary text while still bundling it for playback

## Testing
- node ./tmp-test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68def9c575e48328b497fe4e826273c7