### PR TITLE
Simplify remote monitor player styling

### DIFF
--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -4,6 +4,7 @@ const dom = {
   appShell: document.querySelector('.app-shell'),
   binInfo: $('#binInfo'),
   mainArea: document.querySelector('.main-area'),
+  previewArea: document.querySelector('.preview-area'),
   controlCard: $('#controlCard'),
   controlToggle: $('#controlCardToggle'),
   controlRestore: $('#controlCardRestore'),
@@ -19,6 +20,15 @@ const dom = {
   videoFile: $('#videoFile'),
   pickVideo: $('#pickVideo'),
   useRemoteTimelineToggle: $('#useRemoteTimelineToggle'),
+  remotePlayer: $('#remotePlayer'),
+  remotePlayerCover: $('#remotePlayerCover'),
+  remotePlayerCoverFallback: $('#remotePlayerCoverFallback'),
+  remotePlayerTitle: $('#remotePlayerTitle'),
+  remotePlayerSubtitle: $('#remotePlayerSubtitle'),
+  remotePlayerStatus: $('#remotePlayerStatus'),
+  remotePlayerCurrent: $('#remotePlayerCurrent'),
+  remotePlayerDuration: $('#remotePlayerDuration'),
+  remotePlayerProgressFill: $('#remotePlayerProgressFill'),
   ytUrl: $('#ytUrl'),
   fontsPicked: $('#fontsPicked'),
   pickCookies: $('#pickCookies'),
@@ -89,6 +99,7 @@ const state = {
   remoteLastGuid: '',
   remoteLastUpdate: 0,
   remoteMediaKey: '',
+  remoteProgressTimer: null,
   subtitleOffsetMode: 'advance',
   subtitleOffsetSeconds: 0,
   subtitleOffsetDefaults: { mode: 'advance', seconds: 0 },
@@ -323,6 +334,11 @@ function handleRemoteNowPlaying(raw) {
     }
     applyRemoteMediaUiState();
     updateVideoCacheSelect(state.activeVideoId);
+    updateRemotePlayerUi(payload);
+    startRemoteProgressTimer();
+  } else {
+    updateRemotePlayerUi(payload);
+    stopRemoteProgressTimer();
   }
   updateActiveCacheInfo();
 }
@@ -342,6 +358,160 @@ function applyRemoteTimeline(payload) {
     } else if (payload.status === 'paused' || payload.status === 'stopped') {
       try { video.pause(); } catch { /* noop */ }
     }
+  }
+}
+
+
+function updateRemotePlayerVisibility() {
+  const usingRemote = Boolean(state.useRemoteTimeline);
+  if (dom.previewArea) {
+    dom.previewArea.classList.toggle('remote-active', usingRemote);
+  }
+  if (dom.remotePlayer) {
+    dom.remotePlayer.hidden = !usingRemote;
+    dom.remotePlayer.setAttribute('aria-hidden', usingRemote ? 'false' : 'true');
+  }
+  if (dom.video) {
+    dom.video.controls = !usingRemote;
+    dom.video.classList.toggle('remote-disabled', usingRemote);
+    if (usingRemote) {
+      dom.video.setAttribute('aria-hidden', 'true');
+      dom.video.setAttribute('tabindex', '-1');
+      dom.video.style.pointerEvents = 'none';
+      try { dom.video.pause(); } catch { /* noop */ }
+    } else {
+      dom.video.removeAttribute('aria-hidden');
+      dom.video.removeAttribute('tabindex');
+      dom.video.style.pointerEvents = '';
+    }
+  }
+}
+
+function formatClockTime(seconds) {
+  if (!Number.isFinite(seconds)) return '--:--';
+  const clamped = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const secs = clamped % 60;
+  const mm = String(minutes).padStart(hours > 0 ? 2 : 1, '0');
+  const ss = String(secs).padStart(2, '0');
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+function getRemoteProgressEstimate(info = state.remoteNowPlaying) {
+  if (!info || typeof info !== 'object') {
+    return { progress: null, duration: null };
+  }
+  const progressBase = Number.isFinite(info.progressSeconds)
+    ? info.progressSeconds
+    : (Number.isFinite(info.progressMs) ? info.progressMs / 1000 : null);
+  const duration = Number.isFinite(info.durationSeconds)
+    ? Math.max(0, info.durationSeconds)
+    : (Number.isFinite(info.durationMs) ? Math.max(0, info.durationMs / 1000) : null);
+  let progress = progressBase != null ? Math.max(0, progressBase) : null;
+  const status = String(info.status || '').toLowerCase();
+  const baseTs = Number.isFinite(info.receivedAt) ? info.receivedAt : state.remoteLastUpdate || Date.now();
+  if (progress != null && status === 'playing') {
+    const elapsed = Math.max(0, (Date.now() - baseTs) / 1000);
+    progress += elapsed;
+  }
+  if (progress != null && duration != null && duration > 0) {
+    progress = Math.min(progress, duration);
+  }
+  return { progress, duration };
+}
+
+function updateRemoteProgressDisplay(info = state.remoteNowPlaying) {
+  if (!dom.remotePlayerCurrent || !dom.remotePlayerDuration || !dom.remotePlayerProgressFill) return;
+  const { progress, duration } = getRemoteProgressEstimate(info);
+  const currentText = progress != null ? formatClockTime(progress) : '0:00';
+  dom.remotePlayerCurrent.textContent = currentText;
+  const isLive = info?.isLive === true;
+  if (isLive) {
+    dom.remotePlayerDuration.textContent = 'LIVE';
+    dom.remotePlayerDuration.classList.add('is-live');
+  } else {
+    dom.remotePlayerDuration.classList.remove('is-live');
+    dom.remotePlayerDuration.textContent = (duration != null && duration > 0)
+      ? formatClockTime(duration)
+      : '--:--';
+  }
+  const ratio = (progress != null && duration != null && duration > 0)
+    ? Math.min(1, Math.max(0, progress / duration))
+    : 0;
+  dom.remotePlayerProgressFill.style.width = `${(ratio * 100).toFixed(2)}%`;
+}
+
+function getRemoteStatusLabel(info = state.remoteNowPlaying) {
+  if (!info || typeof info !== 'object') return '等待播放';
+  const status = String(info.status || '').toLowerCase();
+  const isLive = info.isLive === true;
+  if (status === 'playing') return isLive ? '直播中' : '播放中';
+  if (status === 'paused') return isLive ? '直播暫停' : '已暫停';
+  if (status === 'stopped') return isLive ? '直播結束' : '已停止';
+  return info.title || info.artists?.length ? '已連線' : '等待播放';
+}
+
+function updateRemotePlayerUi(info = state.remoteNowPlaying) {
+  if (!dom.remotePlayer) return;
+  const remote = info && typeof info === 'object' ? info : null;
+  const hasRemote = Boolean(remote);
+  const title = remote?.title || '外部時間軸';
+  const artists = Array.isArray(remote?.artists) && remote.artists.length
+    ? remote.artists.join(', ')
+    : '';
+  const platform = remote?.platform ? `@${remote.platform}` : '';
+  const subtitleParts = [artists, platform].filter(Boolean);
+  if (dom.remotePlayerTitle) dom.remotePlayerTitle.textContent = title;
+  if (dom.remotePlayerSubtitle) {
+    dom.remotePlayerSubtitle.textContent = subtitleParts.length
+      ? subtitleParts.join(' · ')
+      : (hasRemote ? '外部時間軸已啟用' : '等待外部播放資訊...');
+  }
+  if (dom.remotePlayerStatus) dom.remotePlayerStatus.textContent = getRemoteStatusLabel(remote);
+
+  const coverUrl = typeof remote?.cover === 'string' ? remote.cover : '';
+  if (dom.remotePlayerCover) {
+    if (coverUrl) {
+      dom.remotePlayerCover.src = coverUrl;
+      dom.remotePlayerCover.alt = title ? `${title} 封面` : '播放封面';
+      dom.remotePlayerCover.hidden = false;
+    } else {
+      dom.remotePlayerCover.hidden = true;
+      dom.remotePlayerCover.removeAttribute('src');
+      dom.remotePlayerCover.removeAttribute('alt');
+    }
+  }
+  if (dom.remotePlayerCoverFallback) {
+    const fallbackChar = remote?.title?.trim()?.[0] || '♪';
+    dom.remotePlayerCoverFallback.textContent = fallbackChar;
+    dom.remotePlayerCoverFallback.hidden = Boolean(coverUrl);
+  }
+
+  const status = String(remote?.status || '').toLowerCase();
+  dom.remotePlayer.classList.toggle('is-playing', status === 'playing');
+  dom.remotePlayer.classList.toggle('is-paused', status === 'paused');
+  dom.remotePlayer.classList.toggle('is-stopped', !status || status === 'stopped');
+
+  updateRemoteProgressDisplay(remote);
+}
+
+function startRemoteProgressTimer() {
+  updateRemoteProgressDisplay();
+  if (state.remoteProgressTimer != null) return;
+  state.remoteProgressTimer = window.setInterval(() => {
+    if (!state.useRemoteTimeline) {
+      stopRemoteProgressTimer();
+      return;
+    }
+    updateRemoteProgressDisplay();
+  }, 500);
+}
+
+function stopRemoteProgressTimer() {
+  if (state.remoteProgressTimer != null) {
+    window.clearInterval(state.remoteProgressTimer);
+    state.remoteProgressTimer = null;
   }
 }
 
@@ -407,6 +577,14 @@ function setRemoteTimelineEnabled(enabled, { persist = false } = {}) {
   }
   updateActiveCacheInfo();
   applyRemoteMediaUiState();
+  updateRemotePlayerVisibility();
+  if (state.useRemoteTimeline) {
+    updateRemotePlayerUi();
+    startRemoteProgressTimer();
+  } else {
+    stopRemoteProgressTimer();
+    updateRemotePlayerUi();
+  }
   updateVideoCacheSelect(state.activeVideoId);
   const canApplyOffset = state.activeSubsId && (!state.useRemoteTimeline || state.remoteMediaKey);
   if (canApplyOffset) {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -577,6 +577,194 @@
       flex-direction: column;
       gap: 12px;
       align-items: center;
+      width: 100%;
+    }
+
+    .preview-area.remote-active #localVideo {
+      display: none;
+    }
+
+    .remote-player {
+      display: none;
+      width: min(560px, 100%);
+      border-radius: 18px;
+      overflow: hidden;
+      background: #000;
+      box-shadow: 0 18px 34px -24px rgba(15, 23, 42, 0.6);
+      color: #f8fafc;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .preview-area.remote-active .remote-player {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .remote-player-media {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background: #111;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    .remote-player-cover {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .remote-player-cover[hidden] {
+      display: none;
+    }
+
+    .remote-player-cover-fallback {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: clamp(36px, 12vw, 72px);
+      font-weight: 600;
+      color: rgba(248, 250, 252, 0.82);
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.25), rgba(124, 58, 237, 0.25));
+      letter-spacing: 0.04em;
+    }
+
+    .remote-player-cover-fallback[hidden] {
+      display: none;
+    }
+
+    .remote-player-controlbar {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 14px;
+      background: rgba(15, 23, 42, 0.92);
+      border-top: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .remote-player-button {
+      width: 32px;
+      height: 32px;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(30, 41, 59, 0.85);
+      color: rgba(226, 232, 240, 0.88);
+      display: grid;
+      place-items: center;
+      font-size: 14px;
+      pointer-events: none;
+      opacity: 0.72;
+    }
+
+    .remote-player-progress {
+      flex: 1 1 auto;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+    }
+
+    .remote-player-timecode {
+      font-size: 12px;
+      color: rgba(226, 232, 240, 0.8);
+      min-width: 44px;
+      text-align: center;
+    }
+
+    .remote-player-progress-track {
+      flex: 1 1 auto;
+      height: 6px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.3);
+      overflow: hidden;
+      position: relative;
+    }
+
+    .remote-player-progress-fill {
+      width: 0%;
+      height: 100%;
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+      border-radius: inherit;
+      transition: width 0.3s ease;
+    }
+
+    .remote-player-volume-icon {
+      font-size: 14px;
+      color: rgba(148, 163, 184, 0.8);
+    }
+
+    .remote-player-meta {
+      padding: 14px 16px 16px;
+      background: rgba(15, 23, 42, 0.78);
+      border-top: 1px solid rgba(148, 163, 184, 0.25);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .remote-player-status {
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      color: rgba(226, 232, 240, 0.76);
+      font-weight: 600;
+    }
+
+    .remote-player-title {
+      margin: 0;
+      font-size: 17px;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .remote-player-subtitle {
+      margin: 0;
+      font-size: 13px;
+      color: rgba(226, 232, 240, 0.7);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .remote-player-duration.is-live {
+      color: #f97316;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+    }
+
+    .remote-player.is-playing .remote-player-button::before {
+      content: '▌▌';
+      font-size: 12px;
+      transform: translateX(-1px);
+    }
+
+    .remote-player:not(.is-playing) .remote-player-button::before {
+      content: '▶';
+      font-size: 13px;
+      transform: translateX(1px);
+    }
+
+    .remote-player.is-stopped .remote-player-button::before {
+      content: '■';
+      transform: translateY(-1px);
+    }
+
+    .remote-player.is-playing .remote-player-status {
+      color: #22c55e;
+    }
+
+    .remote-player.is-paused .remote-player-status {
+      color: #facc15;
+    }
+
+    .remote-player.is-stopped .remote-player-status {
+      color: rgba(226, 232, 240, 0.72);
     }
 
     .in-preview-control-container {
@@ -1000,6 +1188,28 @@
       color: #e2e8f0;
     }
 
+    @media (max-width: 560px) {
+      .remote-player {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+        gap: 18px;
+      }
+
+      .remote-player-meta {
+        align-items: center;
+        text-align: center;
+      }
+
+      .remote-player-status-row {
+        justify-content: center;
+      }
+
+      .remote-player-progress {
+        width: 100%;
+      }
+    }
+
     @media (min-width: 980px) {
       .main-area {
         grid-template-columns: 1fr 1.2fr;
@@ -1110,6 +1320,28 @@
         <div class="card-body">
           <div class="preview-area">
             <video id="localVideo" class="placeholder" controls></video>
+            <div id="remotePlayer" class="remote-player" hidden aria-hidden="true">
+              <div class="remote-player-media">
+                <img id="remotePlayerCover" class="remote-player-cover" alt="外部播放封面" hidden>
+                <div id="remotePlayerCoverFallback" class="remote-player-cover-fallback" aria-hidden="true">♪</div>
+              </div>
+              <div class="remote-player-controlbar" aria-hidden="true">
+                <span class="remote-player-button"></span>
+                <div class="remote-player-progress">
+                  <span id="remotePlayerCurrent" class="remote-player-timecode">0:00</span>
+                  <div class="remote-player-progress-track">
+                    <div id="remotePlayerProgressFill" class="remote-player-progress-fill"></div>
+                  </div>
+                  <span id="remotePlayerDuration" class="remote-player-timecode remote-player-duration">--:--</span>
+                </div>
+                <span class="remote-player-volume-icon" aria-hidden="true">🔈</span>
+              </div>
+              <div class="remote-player-meta">
+                <span id="remotePlayerStatus" class="remote-player-status">等待播放</span>
+                <h3 id="remotePlayerTitle" class="remote-player-title">外部時間軸</h3>
+                <p id="remotePlayerSubtitle" class="remote-player-subtitle">等待外部播放資訊...</p>
+              </div>
+            </div>
           </div>
           <div class="in-preview-control-container">
             <div class="subtitle-offset-panel">


### PR DESCRIPTION
## Summary
- restyle the remote monitor preview to resemble a native video player while showing cover art, timing, and status
- update the monitor markup so the external timeline uses a fixed media area, disabled controls, and metadata strip

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e17e27d8508328984315536b8bd42d