### PR TITLE
feat: replace native selects with custom accessible dropdowns

### DIFF
--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -52,6 +52,384 @@ const dom = {
   binStatusFfmpeg: $('#binStatusFfmpegIcon')
 };
 
+const customSelectInstances = new WeakMap();
+
+class CustomSelect {
+  constructor(select) {
+    this.select = select;
+    this.select.tabIndex = -1;
+    this.select.setAttribute('tabindex', '-1');
+    this.triggerId = `${select.id || `select-${Math.random().toString(36).slice(2)}`}-trigger`;
+    this.valueId = `${select.id || `select-${Math.random().toString(36).slice(2)}`}-value`;
+    this.listId = `${select.id || `select-${Math.random().toString(36).slice(2)}`}-listbox`;
+    this.isOpen = false;
+    this.focusedIndex = -1;
+    this.marqueeGap = 36;
+    this.marqueeRaf = null;
+
+    const label = select.id ? document.querySelector(`label[for="${select.id}"]`) : null;
+    if (label && !label.id) {
+      label.id = `${select.id}Label`;
+    }
+    this.labelEl = label || null;
+
+    this.wrapper = document.createElement('div');
+    this.wrapper.className = 'custom-select';
+    if (select.id) {
+      this.wrapper.dataset.selectId = select.id;
+    }
+
+    this.trigger = document.createElement('button');
+    this.trigger.type = 'button';
+    this.trigger.id = this.triggerId;
+    this.trigger.className = 'custom-select__trigger';
+    this.trigger.setAttribute('aria-haspopup', 'listbox');
+    this.trigger.setAttribute('aria-expanded', 'false');
+    this.trigger.setAttribute('aria-controls', this.listId);
+    if (this.labelEl) {
+      this.trigger.setAttribute('aria-labelledby', `${this.labelEl.id} ${this.valueId}`);
+    } else if (this.select.getAttribute('aria-label')) {
+      this.trigger.setAttribute('aria-label', this.select.getAttribute('aria-label'));
+    }
+
+    this.labelWrap = document.createElement('span');
+    this.labelWrap.className = 'custom-select__label';
+
+    this.marqueeTrack = document.createElement('span');
+    this.marqueeTrack.className = 'custom-select__marquee-track';
+    this.marqueeTrack.dataset.paused = 'false';
+
+    this.marqueePrimary = document.createElement('span');
+    this.marqueePrimary.className = 'custom-select__marquee-item';
+    this.marqueePrimary.id = this.valueId;
+
+    this.marqueeClone = document.createElement('span');
+    this.marqueeClone.className = 'custom-select__marquee-item';
+    this.marqueeClone.setAttribute('aria-hidden', 'true');
+    this.marqueeClone.hidden = true;
+
+    this.marqueeTrack.append(this.marqueePrimary, this.marqueeClone);
+    this.labelWrap.append(this.marqueeTrack);
+    this.trigger.append(this.labelWrap);
+
+    this.chevron = document.createElement('span');
+    this.chevron.className = 'custom-select__chevron';
+    this.chevron.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>`;
+    this.trigger.append(this.chevron);
+
+    this.list = document.createElement('div');
+    this.list.id = this.listId;
+    this.list.className = 'custom-select__list';
+    this.list.setAttribute('role', 'listbox');
+    this.list.setAttribute('tabindex', '-1');
+    this.list.setAttribute('aria-hidden', 'true');
+    if (this.labelEl) {
+      this.list.setAttribute('aria-labelledby', this.labelEl.id);
+    }
+
+    this.wrapper.append(this.trigger, this.list);
+    this.select.insertAdjacentElement('afterend', this.wrapper);
+
+    this.handleDocumentPointerDown = this.handleDocumentPointerDown.bind(this);
+    this.handleTriggerClick = this.handleTriggerClick.bind(this);
+    this.handleTriggerKeyDown = this.handleTriggerKeyDown.bind(this);
+    this.handleListKeyDown = this.handleListKeyDown.bind(this);
+    this.handleListClick = this.handleListClick.bind(this);
+    this.handleListFocusOut = this.handleListFocusOut.bind(this);
+    this.handleNativeChange = this.handleNativeChange.bind(this);
+    this.updateMarquee = this.updateMarquee.bind(this);
+
+    this.trigger.addEventListener('click', this.handleTriggerClick);
+    this.trigger.addEventListener('keydown', this.handleTriggerKeyDown);
+    this.trigger.addEventListener('mouseenter', () => this.setMarqueePaused(true));
+    this.trigger.addEventListener('mouseleave', () => this.setMarqueePaused(false));
+
+    this.list.addEventListener('keydown', this.handleListKeyDown);
+    this.list.addEventListener('click', this.handleListClick);
+    this.list.addEventListener('mousedown', (event) => event.preventDefault());
+    this.list.addEventListener('focusout', this.handleListFocusOut);
+
+    this.select.addEventListener('change', this.handleNativeChange);
+
+    this.options = [];
+    this.buildOptions();
+    this.syncFromSelect();
+    this.syncDisabledState();
+
+    if (typeof ResizeObserver === 'function') {
+      this.resizeObserver = new ResizeObserver(() => this.updateMarquee());
+      this.resizeObserver.observe(this.trigger);
+      this.resizeObserver.observe(this.labelWrap);
+      this.resizeObserver.observe(this.marqueePrimary);
+    } else {
+      this.resizeObserver = null;
+      window.addEventListener('resize', this.updateMarquee);
+    }
+
+    this.attributeObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'disabled') {
+          this.syncDisabledState();
+        }
+      }
+    });
+    this.attributeObserver.observe(this.select, { attributes: true, attributeFilter: ['disabled'] });
+  }
+
+  buildOptions() {
+    this.options = [];
+    this.list.innerHTML = '';
+    Array.from(this.select.options).forEach((option, index) => {
+      const optionEl = document.createElement('div');
+      optionEl.className = 'custom-select__option';
+      optionEl.id = `${this.listId}-option-${index}`;
+      optionEl.setAttribute('role', 'option');
+      optionEl.dataset.index = String(index);
+      optionEl.dataset.value = option.value;
+      optionEl.textContent = option.textContent;
+      optionEl.setAttribute('aria-selected', option.selected ? 'true' : 'false');
+      if (option.disabled) {
+        optionEl.setAttribute('aria-disabled', 'true');
+      }
+      this.list.append(optionEl);
+      this.options.push(optionEl);
+    });
+  }
+
+  handleTriggerClick() {
+    if (this.trigger.disabled) return;
+    this.toggle();
+  }
+
+  handleTriggerKeyDown(event) {
+    if (this.trigger.disabled) return;
+    const { key } = event;
+    if (key === 'ArrowDown' || key === 'ArrowUp') {
+      event.preventDefault();
+      if (!this.isOpen) {
+        this.open();
+      }
+      this.focusOptionByOffset(key === 'ArrowDown' ? 1 : -1);
+    } else if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+      event.preventDefault();
+      this.toggle();
+    } else if (key === 'Escape') {
+      if (this.isOpen) {
+        event.preventDefault();
+        this.close({ restoreFocus: true });
+      }
+    }
+  }
+
+  handleListKeyDown(event) {
+    const { key } = event;
+    if (key === 'ArrowDown' || key === 'ArrowUp') {
+      event.preventDefault();
+      this.focusOptionByOffset(key === 'ArrowDown' ? 1 : -1);
+    } else if (key === 'Home') {
+      event.preventDefault();
+      this.focusOption(0);
+    } else if (key === 'End') {
+      event.preventDefault();
+      this.focusOption(this.options.length - 1);
+    } else if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+      event.preventDefault();
+      this.selectFocusedOption();
+    } else if (key === 'Escape') {
+      event.preventDefault();
+      this.close({ restoreFocus: true });
+    }
+  }
+
+  handleListClick(event) {
+    const optionEl = event.target.closest('.custom-select__option');
+    if (!optionEl) return;
+    if (optionEl.getAttribute('aria-disabled') === 'true') return;
+    const index = Number.parseInt(optionEl.dataset.index, 10);
+    if (Number.isFinite(index)) {
+      this.focusOption(index);
+      this.selectFocusedOption();
+    }
+  }
+
+  handleListFocusOut(event) {
+    if (!this.isOpen) return;
+    const related = event.relatedTarget;
+    if (related && (related === this.trigger || this.list.contains(related))) {
+      return;
+    }
+    this.close({ restoreFocus: false });
+  }
+
+  handleDocumentPointerDown(event) {
+    if (!this.isOpen) return;
+    if (event.target === this.trigger || this.wrapper.contains(event.target)) return;
+    this.close({ restoreFocus: false });
+  }
+
+  handleNativeChange() {
+    this.syncFromSelect();
+  }
+
+  syncFromSelect() {
+    const selectedIndex = this.select.selectedIndex;
+    if (selectedIndex >= 0 && selectedIndex < this.options.length) {
+      this.options.forEach((optionEl, index) => {
+        const isSelected = index === selectedIndex;
+        optionEl.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+        if (!isSelected) optionEl.removeAttribute('data-active');
+      });
+      const selectedOption = this.select.options[selectedIndex];
+      this.marqueePrimary.textContent = selectedOption ? selectedOption.textContent : '';
+      this.marqueeClone.textContent = this.marqueePrimary.textContent;
+      this.focusedIndex = selectedIndex;
+    } else {
+      this.options.forEach((optionEl) => {
+        optionEl.setAttribute('aria-selected', 'false');
+        optionEl.removeAttribute('data-active');
+      });
+      this.marqueePrimary.textContent = '';
+      this.marqueeClone.textContent = '';
+      this.focusedIndex = -1;
+    }
+    this.updateMarquee();
+  }
+
+  syncDisabledState() {
+    this.trigger.disabled = this.select.disabled;
+  }
+
+  setMarqueePaused(paused) {
+    this.marqueeTrack.dataset.paused = paused ? 'true' : 'false';
+  }
+
+  updateMarquee() {
+    if (this.marqueeRaf) {
+      cancelAnimationFrame(this.marqueeRaf);
+      this.marqueeRaf = null;
+    }
+    this.marqueeRaf = requestAnimationFrame(() => {
+      const wrapWidth = this.labelWrap.clientWidth || 0;
+      const textWidth = this.marqueePrimary.scrollWidth || 0;
+      if (!wrapWidth || textWidth <= wrapWidth + 1) {
+        this.marqueeTrack.classList.remove('is-marquee');
+        this.marqueeTrack.style.removeProperty('--marquee-shift');
+        this.marqueeTrack.style.removeProperty('--marquee-duration');
+        this.marqueeClone.hidden = true;
+        this.marqueeTrack.style.transform = 'translateX(0)';
+      } else {
+        const travel = textWidth + this.marqueeGap;
+        const duration = Math.max(6, travel / 28);
+        this.marqueeTrack.classList.add('is-marquee');
+        this.marqueeTrack.style.removeProperty('transform');
+        this.marqueeTrack.style.setProperty('--marquee-shift', `${travel}px`);
+        this.marqueeTrack.style.setProperty('--marquee-duration', `${duration}s`);
+        this.marqueeClone.hidden = false;
+      }
+    });
+  }
+
+  focusOption(index) {
+    if (!Number.isFinite(index)) return;
+    const normalized = Math.max(0, Math.min(index, this.options.length - 1));
+    const optionEl = this.options[normalized];
+    if (!optionEl || optionEl.getAttribute('aria-disabled') === 'true') return;
+    this.focusedIndex = normalized;
+    this.list.setAttribute('aria-activedescendant', optionEl.id);
+    this.options.forEach((el) => {
+      if (el !== optionEl) el.removeAttribute('data-active');
+    });
+    optionEl.setAttribute('data-active', 'true');
+    optionEl.scrollIntoView({ block: 'nearest' });
+  }
+
+  focusOptionByOffset(offset) {
+    if (!Number.isFinite(offset) || this.options.length === 0) return;
+    let index = this.focusedIndex;
+    const start = Number.isFinite(index) && index >= 0 ? index : this.select.selectedIndex;
+    index = Number.isFinite(start) && start >= 0 ? start : 0;
+    let nextIndex = index;
+    const direction = offset > 0 ? 1 : -1;
+    do {
+      nextIndex += direction;
+    } while (
+      nextIndex >= 0 &&
+      nextIndex < this.options.length &&
+      this.options[nextIndex]?.getAttribute('aria-disabled') === 'true'
+    );
+    if (nextIndex < 0 || nextIndex >= this.options.length) return;
+    this.focusOption(nextIndex);
+  }
+
+  selectFocusedOption() {
+    if (this.focusedIndex < 0 || this.focusedIndex >= this.options.length) return;
+    const optionEl = this.options[this.focusedIndex];
+    if (!optionEl || optionEl.getAttribute('aria-disabled') === 'true') return;
+    const value = optionEl.dataset.value;
+    if (this.select.value !== value) {
+      this.select.value = value;
+      const changeEvent = new Event('change', { bubbles: true });
+      this.select.dispatchEvent(changeEvent);
+    } else {
+      this.syncFromSelect();
+    }
+    this.close({ restoreFocus: true });
+  }
+
+  open() {
+    if (this.isOpen || this.trigger.disabled) return;
+    this.isOpen = true;
+    this.list.setAttribute('aria-hidden', 'false');
+    this.trigger.setAttribute('aria-expanded', 'true');
+    document.addEventListener('pointerdown', this.handleDocumentPointerDown, true);
+    requestAnimationFrame(() => {
+      this.list.focus();
+      const selectedIndex = this.select.selectedIndex;
+      if (selectedIndex >= 0) {
+        this.focusOption(selectedIndex);
+      } else if (this.options.length) {
+        this.focusOption(0);
+      }
+    });
+  }
+
+  close({ restoreFocus } = { restoreFocus: false }) {
+    if (!this.isOpen) return;
+    this.isOpen = false;
+    this.list.setAttribute('aria-hidden', 'true');
+    this.list.removeAttribute('aria-activedescendant');
+    this.options.forEach((el) => el.removeAttribute('data-active'));
+    this.trigger.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('pointerdown', this.handleDocumentPointerDown, true);
+    if (restoreFocus) {
+      this.trigger.focus();
+    }
+  }
+
+  toggle() {
+    if (this.isOpen) {
+      this.close({ restoreFocus: false });
+    } else {
+      this.open();
+    }
+  }
+}
+
+function initCustomSelects(root = document) {
+  const selects = root.querySelectorAll('select[data-custom-select="true"]');
+  selects.forEach((select) => {
+    if (customSelectInstances.has(select)) return;
+    const instance = new CustomSelect(select);
+    customSelectInstances.set(select, instance);
+    select._customSelectInstance = instance;
+  });
+}
+
+function refreshCustomSelect(select) {
+  const instance = customSelectInstances.get(select ?? null);
+  if (instance) instance.syncFromSelect();
+}
+
 const videoCacheControls = createCacheSelector(dom.videoFile?.closest('.row'), {
   searchPlaceholder: '搜尋影片或音訊...'
 });
@@ -95,6 +473,8 @@ const state = {
   subtitleOffsetOverrides: {},
   overlayRefreshSeq: 0
 };
+
+initCustomSelects();
 
 const ALIGN_OPTIONS = new Set([
   'top-left',
@@ -777,8 +1157,10 @@ async function loadInitialConfig() {
   if (output.maxHeight != null) dom.maxHeight.value = String(output.maxHeight);
   if (dom.align) {
     dom.align.value = normalizeAlignValue(output.align ?? dom.align.value);
+    refreshCustomSelect(dom.align);
   }
   if (output.background) dom.background.value = output.background;
+  if (dom.background) refreshCustomSelect(dom.background);
   const defaultModeRaw = output?.subtitleOffsetDefaults?.mode ?? output.subtitleOffsetMode;
   const defaultSecondsRaw = output?.subtitleOffsetDefaults?.seconds ?? output.subtitleOffsetSeconds;
   state.subtitleOffsetDefaults = {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -519,6 +519,165 @@
       }
     }
 
+    .native-select[data-custom-select="true"] {
+      position: absolute !important;
+      width: 1px !important;
+      height: 1px !important;
+      padding: 0 !important;
+      margin: -1px !important;
+      overflow: hidden !important;
+      clip: rect(0 0 0 0) !important;
+      clip-path: inset(50%) !important;
+      border: 0 !important;
+      white-space: nowrap !important;
+    }
+
+    .row .custom-select {
+      flex: 1 1 auto;
+      min-width: 180px;
+    }
+
+    .custom-select {
+      position: relative;
+      display: inline-flex;
+      width: 100%;
+    }
+
+    .custom-select__trigger {
+      appearance: none;
+      border: 1px solid rgba(148, 163, 184, 0.55);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.85);
+      color: var(--text-primary);
+      font: inherit;
+      padding: 10px 44px 10px 16px;
+      width: 100%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      cursor: pointer;
+      transition: border-color 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+      text-align: left;
+    }
+
+    .custom-select__trigger:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    .custom-select__trigger:focus-visible {
+      outline: none;
+      border-color: rgba(37, 99, 235, 0.75);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+    }
+
+    .custom-select__trigger[aria-expanded="true"] {
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(124, 58, 237, 0.12));
+    }
+
+    .custom-select__label {
+      flex: 1 1 auto;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      overflow: hidden;
+    }
+
+    .custom-select__marquee-track {
+      display: flex;
+      align-items: center;
+      gap: 36px;
+      transform: translateX(var(--marquee-offset, 0));
+      will-change: transform;
+    }
+
+    .custom-select__marquee-track.is-marquee {
+      animation: custom-select-marquee var(--marquee-duration, 10s) linear infinite;
+    }
+
+    .custom-select__marquee-track[data-paused="true"] {
+      animation-play-state: paused;
+    }
+
+    .custom-select__marquee-item {
+      display: inline-flex;
+      white-space: nowrap;
+      font-weight: 600;
+    }
+
+    .custom-select__chevron {
+      position: absolute;
+      right: 16px;
+      top: 50%;
+      transform: translateY(-50%);
+      pointer-events: none;
+      display: inline-flex;
+      color: #1f2937;
+    }
+
+    .custom-select__list {
+      position: absolute;
+      inset: auto 0 0 0;
+      transform: translateY(calc(100% + 6px));
+      background: #fff;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.55);
+      box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      max-height: 240px;
+      overflow: auto;
+      z-index: 20;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.15s ease, visibility 0.15s ease;
+    }
+
+    .custom-select__list[aria-hidden="false"] {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .custom-select__option {
+      border-radius: 10px;
+      padding: 8px 12px;
+      font-weight: 500;
+      color: var(--text-primary);
+      cursor: pointer;
+      transition: background-color 0.15s ease, color 0.15s ease;
+    }
+
+    .custom-select__option[aria-selected="true"] {
+      background: rgba(37, 99, 235, 0.12);
+      color: #1d4ed8;
+    }
+
+    .custom-select__option[data-active="true"] {
+      background: rgba(37, 99, 235, 0.18);
+      color: #1d4ed8;
+    }
+
+    .custom-select__option[aria-disabled="true"] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .custom-select__option:focus-visible {
+      outline: none;
+    }
+
+    @keyframes custom-select-marquee {
+      0% {
+        transform: translateX(0);
+      }
+      100% {
+        transform: translateX(calc(-1 * var(--marquee-shift, 0px)));
+      }
+    }
+
 
     #videoFile {
       display: none;
@@ -1207,8 +1366,8 @@
             <input type="number" id="maxHeight" value="1080" min="180">
           </div>
           <div class="row">
-            <label for="align">強制對齊</label>
-            <select id="align">
+            <label id="alignLabel" for="align">強制對齊</label>
+            <select id="align" class="native-select" data-custom-select="true" aria-hidden="true">
               <option value="off" selected>關閉</option>
               <option value="top-left">左上</option>
               <option value="top-center">中上</option>
@@ -1222,8 +1381,8 @@
             </select>
           </div>
           <div class="row">
-            <label for="background">背景</label>
-            <select id="background">
+            <label id="backgroundLabel" for="background">背景</label>
+            <select id="background" class="native-select" data-custom-select="true" aria-hidden="true">
               <option value="transparent" selected>透明</option>
               <option value="green">綠幕</option>
             </select>


### PR DESCRIPTION
## Summary
- replace the native alignment/background selects with hidden sources and render custom dropdown UIs
- add an accessible CustomSelect controller with keyboard navigation, ARIA wiring, and marquee text animation for overflowing selections
- refresh the overlay config initialization to keep the custom widgets in sync with stored values

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1817a03448328ab6f6cb5622aab05