### PR TITLE
Avoid resetting remote select marquee on websocket updates

### DIFF
--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -327,8 +327,12 @@ function enhanceCustomSelect(select) {
     });
     const selectedOption = options[selectedIndex] || options.find((option) => option && !option.disabled) || null;
     const label = selectedOption ? (selectedOption.textContent || selectedOption.label || '') : '';
-    primaryText.textContent = label;
-    cloneText.textContent = label;
+    if (primaryText.textContent !== label) {
+      primaryText.textContent = label;
+    }
+    if (cloneText.textContent !== label) {
+      cloneText.textContent = label;
+    }
     if (selectedOption?.title) trigger.title = selectedOption.title;
     else trigger.removeAttribute('title');
     if (!preserveActive) {
@@ -348,7 +352,9 @@ function enhanceCustomSelect(select) {
     const { marquee, clone } = marqueeParts;
     stopMarqueeAnimation(marquee);
     marquee.classList.remove('is-marquee');
-    clone.textContent = '';
+    if (clone.textContent !== '') {
+      clone.textContent = '';
+    }
     marquee.style.removeProperty('--marquee-distance');
     marquee.style.removeProperty('--marquee-duration');
   }
@@ -363,7 +369,10 @@ function enhanceCustomSelect(select) {
       stopOptionMarquee(optionEl);
       return;
     }
-    clone.textContent = primary.textContent;
+    const cloneLabel = primary.textContent || '';
+    if (clone.textContent !== cloneLabel) {
+      clone.textContent = cloneLabel;
+    }
     const gapValue = (() => {
       const style = window.getComputedStyle(marquee);
       const gap = parseFloat(style.columnGap || style.gap || '0');
@@ -475,14 +484,19 @@ function enhanceCustomSelect(select) {
     if (!containerWidth || !textWidth) {
       stopMarqueeAnimation(marquee);
       marquee.classList.remove('is-marquee');
-      cloneText.textContent = '';
+      if (cloneText.textContent !== '') {
+        cloneText.textContent = '';
+      }
       marquee.style.removeProperty('--marquee-distance');
       marquee.style.removeProperty('--marquee-duration');
       return;
     }
     if (textWidth > containerWidth + 2) {
       marquee.classList.add('is-marquee');
-      cloneText.textContent = primaryText.textContent;
+      const primaryLabel = primaryText.textContent || '';
+      if (cloneText.textContent !== primaryLabel) {
+        cloneText.textContent = primaryLabel;
+      }
       const gapValue = (() => {
         const style = window.getComputedStyle(marquee);
         const gap = parseFloat(style.columnGap || style.gap || '0');
@@ -501,7 +515,9 @@ function enhanceCustomSelect(select) {
     } else {
       stopMarqueeAnimation(marquee);
       marquee.classList.remove('is-marquee');
-      cloneText.textContent = '';
+      if (cloneText.textContent !== '') {
+        cloneText.textContent = '';
+      }
       marquee.style.removeProperty('--marquee-distance');
       marquee.style.removeProperty('--marquee-duration');
     }

--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -489,14 +489,17 @@ function enhanceCustomSelect(select) {
       }
       marquee.style.removeProperty('--marquee-distance');
       marquee.style.removeProperty('--marquee-duration');
+      delete marquee.dataset.marqueeLabel;
+      delete marquee.dataset.marqueeDistance;
+      delete marquee.dataset.marqueeDuration;
       return;
     }
     if (textWidth > containerWidth + 2) {
-      marquee.classList.add('is-marquee');
       const primaryLabel = primaryText.textContent || '';
       if (cloneText.textContent !== primaryLabel) {
         cloneText.textContent = primaryLabel;
       }
+      const previousLabel = marquee.dataset.marqueeLabel || '';
       const gapValue = (() => {
         const style = window.getComputedStyle(marquee);
         const gap = parseFloat(style.columnGap || style.gap || '0');
@@ -504,11 +507,31 @@ function enhanceCustomSelect(select) {
       })();
       const distance = textWidth + gapValue;
       const duration = Math.max(6, Math.min(30, distance / 36));
-      marquee.style.setProperty('--marquee-distance', `${distance}px`);
-      marquee.style.setProperty('--marquee-duration', `${duration}s`);
-      if (marquee.dataset.interacting === 'true') {
+      const distanceValue = `${distance}px`;
+      const durationValue = `${duration}s`;
+      const previousDistance = marquee.dataset.marqueeDistance || '';
+      const previousDuration = marquee.dataset.marqueeDuration || '';
+      const distanceChanged = previousDistance !== distanceValue;
+      const durationChanged = previousDuration !== durationValue;
+      const labelChanged = previousLabel !== primaryLabel;
+      marquee.dataset.marqueeLabel = primaryLabel;
+      marquee.dataset.marqueeDistance = distanceValue;
+      marquee.dataset.marqueeDuration = durationValue;
+      if (marquee.style.getPropertyValue('--marquee-distance') !== distanceValue) {
+        marquee.style.setProperty('--marquee-distance', distanceValue);
+      }
+      if (marquee.style.getPropertyValue('--marquee-duration') !== durationValue) {
+        marquee.style.setProperty('--marquee-duration', durationValue);
+      }
+      const wasMarquee = marquee.classList.contains('is-marquee');
+      if (!wasMarquee) {
+        marquee.classList.add('is-marquee');
+      }
+      const interacting = marquee.dataset.interacting === 'true';
+      const shouldRestart = interacting && (!wasMarquee || labelChanged || distanceChanged || durationChanged);
+      if (shouldRestart) {
         startMarqueeAnimation(marquee);
-      } else {
+      } else if (!interacting) {
         marquee.dataset.paused = 'true';
         marquee.classList.remove('is-animating');
       }
@@ -520,6 +543,9 @@ function enhanceCustomSelect(select) {
       }
       marquee.style.removeProperty('--marquee-distance');
       marquee.style.removeProperty('--marquee-duration');
+      delete marquee.dataset.marqueeLabel;
+      delete marquee.dataset.marqueeDistance;
+      delete marquee.dataset.marqueeDuration;
     }
   }
 

--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -1209,15 +1209,36 @@ function applyRemoteMediaUiState() {
   select.classList.toggle('is-remote-disabled', usingRemote);
   if (usingRemote) {
     const label = getRemoteMediaLabel();
-    select.innerHTML = '';
-    const option = new Option(label, '', true, true);
-    option.disabled = true;
-    select.add(option);
+    const previousLabel = select.dataset.remoteLabel || '';
+    const hasSingleOption = select.options.length === 1;
+    const currentOption = hasSingleOption ? select.options[0] : null;
+    const needsRebuild =
+      !currentOption ||
+      currentOption.value !== '' ||
+      currentOption.disabled !== true ||
+      currentOption.textContent !== label;
+
     select.disabled = true;
+
+    if (needsRebuild) {
+      select.innerHTML = '';
+      const option = new Option(label, '', true, true);
+      option.disabled = true;
+      select.add(option);
+      refreshCustomSelect(select, { rebuildOptions: true });
+    } else if (previousLabel !== label) {
+      refreshCustomSelect(select, { rebuildOptions: true });
+    }
+
+    if (select.dataset.remoteLabel !== label) {
+      select.dataset.remoteLabel = label;
+    }
   } else {
     select.disabled = false;
+    if (select.dataset.remoteLabel) {
+      delete select.dataset.remoteLabel;
+    }
   }
-  refreshCustomSelect(select, { rebuildOptions: true });
 }
 
 function setRemoteTimelineEnabled(enabled, { persist = false } = {}) {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -530,7 +530,7 @@
     }
 
     .custom-select__trigger[aria-disabled="true"] {
-      cursor: not-allowed;
+      cursor: default;
       opacity: 0.6;
     }
 
@@ -661,7 +661,7 @@
     }
 
     .custom-select__option[aria-disabled="true"] {
-      cursor: not-allowed;
+      cursor: default;
       color: rgba(71, 85, 105, 0.6);
     }
 
@@ -677,7 +677,7 @@
     }
 
     .custom-select.is-disabled .custom-select__trigger {
-      cursor: not-allowed;
+      cursor: default;
       opacity: 0.6;
       background: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.1));
     }


### PR DESCRIPTION
## Summary
- avoid rebuilding the cached video custom select when remote timeline updates do not change the label
- preserve the existing option and dataset state so marquee animations keep running between websocket events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1af9db36c83288b3146d3aa4a6e0d