### PR TITLE
fix: keep remote monitor locked to selected session

### DIFF
--- a/src/main/overlayServer.mjs
+++ b/src/main/overlayServer.mjs
@@ -90,6 +90,7 @@ function normalizeNowPlayingPayload(raw) {
     ? raw.artists.map((name) => normalizeStr(name)).filter(Boolean)
     : [];
   return {
+    sessionKey: normalizeStr(raw?.sessionKey ?? raw?.session_key),
     guid: normalizeStr(raw?.guid),
     cover: normalizeStr(raw?.cover),
     title: normalizeStr(raw?.title),
@@ -470,6 +471,13 @@ export class OverlayServer {
   }
   deriveSessionKey(payload) {
     if (!payload || typeof payload !== 'object') return 'unknown';
+    const existing = sanitizeRemoteIdentity(payload.sessionKey);
+    if (existing) {
+      if (this.remoteSessions.has(existing)) return existing;
+      const prefixed = existing.startsWith('guid:') ? existing : `guid:${existing}`;
+      if (this.remoteSessions.has(prefixed)) return prefixed;
+      return existing;
+    }
     if (payload.guid) return `guid:${payload.guid}`;
     if (payload.songLink) return `song:${payload.songLink}`;
     const platform = typeof payload.platform === 'string' ? payload.platform.trim().toLowerCase() : '';
@@ -624,10 +632,14 @@ export class OverlayServer {
           artists: Array.isArray(info.artists) ? info.artists : [],
           status: info.status || '',
           progressMs: info.progressMs ?? null,
+          progressSeconds: info.progressSeconds ?? null,
           durationMs: info.durationMs ?? null,
+          durationSeconds: info.durationSeconds ?? null,
+          receivedAt: info.receivedAt ?? session?.lastUpdate ?? 0,
           songLink: info.songLink || '',
           platform: info.platform || '',
-          isLive: info.isLive === true
+          isLive: info.isLive === true,
+          guid: info.guid || ''
         } : null
       });
     }

--- a/src/main/overlayServer.mjs
+++ b/src/main/overlayServer.mjs
@@ -31,6 +31,8 @@ const FONT_WEIGHT_PATTERNS = [
   { regex: /\bblack\b/gi, weight: 900 }
 ];
 const FONT_ITALIC_PATTERNS = [/\bitalic\b/gi, /\boblique\b/gi];
+const REMOTE_PROGRESS_EPSILON_SECONDS = 0.25;
+const REMOTE_STALL_TIME_MS = 1500;
 
 function mergeStyles(currentStyle, patchStyle) {
   const base = (currentStyle && typeof currentStyle === 'object') ? currentStyle : {};
@@ -102,6 +104,44 @@ function normalizeNowPlayingPayload(raw) {
     isLive: raw?.is_live === true,
     receivedAt: Date.now()
   };
+}
+
+function getProgressSeconds(info) {
+  if (!info || typeof info !== 'object') return null;
+  if (Number.isFinite(info.progressSeconds)) return Math.max(0, info.progressSeconds);
+  if (Number.isFinite(info.progressMs)) return Math.max(0, info.progressMs / 1000);
+  return null;
+}
+
+function sanitizeRemoteIdentity(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function sanitizeRemoteName(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function areSameRemoteEntries(prev, next) {
+  if (!prev || !next || typeof prev !== 'object' || typeof next !== 'object') return false;
+  const prevGuid = sanitizeRemoteIdentity(prev.guid);
+  const nextGuid = sanitizeRemoteIdentity(next.guid);
+  if (prevGuid && nextGuid) return prevGuid === nextGuid;
+  const prevSong = sanitizeRemoteIdentity(prev.songLink);
+  const nextSong = sanitizeRemoteIdentity(next.songLink);
+  if (prevSong && nextSong) return prevSong === nextSong;
+  const prevTitle = sanitizeRemoteName(prev.title);
+  const nextTitle = sanitizeRemoteName(next.title);
+  if (!prevTitle || !nextTitle || prevTitle !== nextTitle) return false;
+  const prevPlatform = sanitizeRemoteName(prev.platform);
+  const nextPlatform = sanitizeRemoteName(next.platform);
+  if (prevPlatform && nextPlatform && prevPlatform !== nextPlatform) return false;
+  const joinArtists = (artists) => Array.isArray(artists)
+    ? artists.map((name) => sanitizeRemoteName(name)).filter(Boolean).join('|')
+    : '';
+  const prevArtists = joinArtists(prev.artists);
+  const nextArtists = joinArtists(next.artists);
+  if (prevArtists && nextArtists) return prevArtists === nextArtists;
+  return true;
 }
 function analyseFontName(name) {
   if (typeof name !== 'string') {
@@ -248,6 +288,7 @@ export class OverlayServer {
     };
     this.remoteSessions = new Map();
     this.activeSessionKey = '';
+    this.selectedSessionKey = '';
     this.nowPlaying = null;
 
     this.app = express();
@@ -347,6 +388,7 @@ export class OverlayServer {
       if (this.nowPlaying) {
         try { ws.send(JSON.stringify({ type: 'nowPlaying', payload: this.nowPlaying })); } catch { /* noop */ }
       }
+      this.sendRemoteSessions(ws);
       ws.on('message', msg => {
         let data = msg;
         if (Buffer.isBuffer(data)) {
@@ -362,13 +404,22 @@ export class OverlayServer {
         const trimmed = data.trim();
         if (!trimmed) return;
         const firstChar = trimmed[0];
-        if (firstChar !== '{' && firstChar !== '[') return;
+        if (firstChar !== '{' && firstChar !== '[') {
+          if (trimmed.startsWith('connected')) {
+            this.handleRemoteClientHandshake(trimmed, { closed: false });
+          } else if (trimmed.startsWith('closed')) {
+            this.handleRemoteClientHandshake(trimmed, { closed: true });
+          }
+          return;
+        }
         let parsed;
         try { parsed = JSON.parse(trimmed); } catch { return; }
         if (!parsed || typeof parsed !== 'object') return;
         const { type, payload } = parsed;
         if (type === 'setTime') {
           this.broadcast({ type: 'setTime', payload });
+        } else if (type === 'setActiveSession') {
+          this.setActiveSessionKey(payload?.key);
         } else if (type === 'nowPlaying' && payload) {
           this.updateNowPlaying(payload);
         } else if (looksLikeNowPlayingPayload(parsed)) {
@@ -376,6 +427,46 @@ export class OverlayServer {
         }
       });
     });
+  }
+  handleRemoteClientHandshake(message, { closed = false } = {}) {
+    const match = /^(?:connected|closed)\s*-\s*(.+)\s*\(([^)]+)\)\s*$/i.exec(message);
+    if (!match) return;
+    const host = (match[1] || '').trim();
+    const guid = (match[2] || '').trim();
+    if (!guid) return;
+    const key = `guid:${guid}`;
+    const now = Date.now();
+    if (closed) {
+      const session = this.remoteSessions.get(key);
+      if (!session) return;
+      const wasActive = this.activeSessionKey === key;
+      const wasSelected = this.selectedSessionKey === key;
+      this.remoteSessions.delete(key);
+      if (wasActive) {
+        this.activeSessionKey = '';
+        this.nowPlaying = null;
+      }
+      if (wasSelected) {
+        this.selectedSessionKey = '';
+      }
+      if (wasActive || wasSelected) {
+        this.setActiveSessionKey(this.selectedSessionKey);
+      } else {
+        this.emitRemoteSessions();
+      }
+      return;
+    }
+    const session = this.remoteSessions.get(key) || { lastPlayTs: 0, status: 'stopped' };
+    session.host = host;
+    session.guid = guid;
+    session.connected = true;
+    session.lastSeen = now;
+    if (!session.lastUpdate) session.lastUpdate = now;
+    this.remoteSessions.set(key, session);
+    if (!this.selectedSessionKey) {
+      this.selectedSessionKey = key;
+    }
+    this.emitRemoteSessions();
   }
   deriveSessionKey(payload) {
     if (!payload || typeof payload !== 'object') return 'unknown';
@@ -387,11 +478,34 @@ export class OverlayServer {
     return 'unknown';
   }
 
-  selectActiveSession() {
+  selectActiveSession({ preferSelected = true } = {}) {
+    let selectedSession = null;
+    if (this.selectedSessionKey) {
+      selectedSession = this.remoteSessions.get(this.selectedSessionKey) || null;
+      const status = String(selectedSession?.status || '').toLowerCase();
+      if (!selectedSession || status === 'stopped') {
+        this.selectedSessionKey = '';
+        selectedSession = null;
+      }
+    }
+    if (preferSelected && this.selectedSessionKey && selectedSession) {
+      return this.selectedSessionKey;
+    }
+
+    let activeSession = null;
+    if (this.activeSessionKey) {
+      activeSession = this.remoteSessions.get(this.activeSessionKey) || null;
+      const status = String(activeSession?.status || '').toLowerCase();
+      if (!activeSession || status === 'stopped') {
+        this.activeSessionKey = '';
+        activeSession = null;
+      }
+    }
     let bestKey = '';
     let bestTs = -1;
     for (const [key, session] of this.remoteSessions) {
       const status = String(session?.status || '').toLowerCase();
+      if (status === 'stopped') continue;
       if (status === 'playing') {
         const ts = session.lastPlayTs ?? session.lastUpdate ?? 0;
         if (ts >= bestTs) {
@@ -401,10 +515,12 @@ export class OverlayServer {
       }
     }
     if (bestKey) return bestKey;
-    if (this.activeSessionKey && this.remoteSessions.has(this.activeSessionKey)) return this.activeSessionKey;
+    if (this.activeSessionKey && activeSession) return this.activeSessionKey;
     let fallbackKey = '';
     let fallbackTs = -1;
     for (const [key, session] of this.remoteSessions) {
+      const status = String(session?.status || '').toLowerCase();
+      if (status === 'stopped') continue;
       const ts = session.lastUpdate ?? 0;
       if (ts >= fallbackTs) {
         fallbackTs = ts;
@@ -421,9 +537,29 @@ export class OverlayServer {
     const now = Date.now();
     const session = this.remoteSessions.get(sessionKey) || { lastPlayTs: 0, status: 'stopped' };
     const previousStatus = String(session.status || '').toLowerCase();
-    session.nowPlaying = normalized;
+    const previousInfo = session.nowPlaying || null;
+    const previousProgress = getProgressSeconds(previousInfo);
+    const nextProgress = getProgressSeconds(normalized);
+    const previousReceivedAt = Number(previousInfo?.receivedAt) || session.lastUpdate || 0;
+    const nextReceivedAt = Number(normalized.receivedAt) || now;
+    const normalizedWithKey = { ...normalized, sessionKey };
+    const sameEntry = areSameRemoteEntries(previousInfo, normalizedWithKey);
+    const elapsedMs = previousReceivedAt > 0 ? Math.max(0, nextReceivedAt - previousReceivedAt) : 0;
+    if (
+      normalized.status === 'playing' &&
+      previousInfo &&
+      nextProgress != null &&
+      previousProgress != null &&
+      elapsedMs >= REMOTE_STALL_TIME_MS &&
+      Math.abs(nextProgress - previousProgress) <= REMOTE_PROGRESS_EPSILON_SECONDS &&
+      sameEntry
+    ) {
+      normalized.status = 'paused';
+      normalizedWithKey.status = 'paused';
+    }
+    session.nowPlaying = normalizedWithKey;
     session.lastUpdate = now;
-    session.status = String(normalized.status || '').toLowerCase();
+    session.status = String(normalizedWithKey.status || '').toLowerCase();
     if (session.status === 'playing' && previousStatus !== 'playing') {
       session.lastPlayTs = now;
     }
@@ -459,6 +595,115 @@ export class OverlayServer {
       const age = now - (sessionData.lastUpdate ?? now);
       if (age > STALE_WINDOW) this.remoteSessions.delete(key);
     }
+    if (this.activeSessionKey && !this.remoteSessions.has(this.activeSessionKey)) {
+      this.activeSessionKey = '';
+      this.nowPlaying = null;
+    }
+    if (this.selectedSessionKey && !this.remoteSessions.has(this.selectedSessionKey)) {
+      this.selectedSessionKey = '';
+    }
+    this.emitRemoteSessions();
+  }
+  buildRemoteSessionsPayload() {
+    const sessions = [];
+    for (const [key, session] of this.remoteSessions) {
+      const status = String(session?.status || '').toLowerCase();
+      if (status === 'stopped') continue;
+      const info = session?.nowPlaying || null;
+      sessions.push({
+        key,
+        host: session?.host || '',
+        status: session?.status || 'unknown',
+        lastUpdate: session?.lastUpdate || 0,
+        lastPlayTs: session?.lastPlayTs || 0,
+        connected: session?.connected !== false,
+        guid: session?.guid || info?.guid || '',
+        nowPlaying: info ? {
+          sessionKey: info.sessionKey || key,
+          title: info.title || '',
+          artists: Array.isArray(info.artists) ? info.artists : [],
+          status: info.status || '',
+          progressMs: info.progressMs ?? null,
+          durationMs: info.durationMs ?? null,
+          songLink: info.songLink || '',
+          platform: info.platform || '',
+          isLive: info.isLive === true
+        } : null
+      });
+    }
+    sessions.sort((a, b) => {
+      const playA = Number(a?.lastPlayTs) || 0;
+      const playB = Number(b?.lastPlayTs) || 0;
+      if (playA !== playB) return playB - playA;
+      const updateA = Number(a?.lastUpdate) || 0;
+      const updateB = Number(b?.lastUpdate) || 0;
+      if (updateA !== updateB) return updateB - updateA;
+      const statusA = (a?.status || '').toLowerCase();
+      const statusB = (b?.status || '').toLowerCase();
+      if (statusA !== statusB) {
+        const rank = { playing: 2, paused: 1 };
+        const scoreA = rank[statusA] || 0;
+        const scoreB = rank[statusB] || 0;
+        if (scoreA !== scoreB) return scoreB - scoreA;
+      }
+      return a.key.localeCompare(b.key);
+    });
+    const hasActive = this.activeSessionKey && sessions.some((session) => session.key === this.activeSessionKey);
+    const hasSelected = this.selectedSessionKey && sessions.some((session) => session.key === this.selectedSessionKey);
+    const activeKey = hasActive ? this.activeSessionKey : '';
+    const selectedKey = hasSelected ? this.selectedSessionKey : '';
+    return {
+      type: 'remoteSessions',
+      payload: {
+        activeKey,
+        selectedKey,
+        sessions
+      }
+    };
+  }
+  emitRemoteSessions() {
+    if (!this.wss?.clients?.size) return;
+    const message = this.buildRemoteSessionsPayload();
+    this.broadcast(message);
+  }
+  sendRemoteSessions(ws) {
+    if (!ws || ws.readyState !== WS_READY_STATE_OPEN) return;
+    const message = this.buildRemoteSessionsPayload();
+    try { ws.send(JSON.stringify(message)); } catch { /* noop */ }
+  }
+  setActiveSessionKey(key) {
+    const normalized = typeof key === 'string' ? key.trim() : '';
+    const session = normalized ? this.remoteSessions.get(normalized) : null;
+    const status = String(session?.status || '').toLowerCase();
+    const exists = Boolean(normalized && session && status !== 'stopped');
+    this.selectedSessionKey = exists ? normalized : '';
+    const previousActive = this.activeSessionKey;
+    if (exists) {
+      this.activeSessionKey = normalized;
+    } else {
+      this.activeSessionKey = this.selectActiveSession({ preferSelected: false });
+    }
+    const activeSession = this.activeSessionKey ? this.remoteSessions.get(this.activeSessionKey) : null;
+    const activePayload = activeSession?.nowPlaying || null;
+    if (activePayload) {
+      const changed = previousActive !== this.activeSessionKey || this.nowPlaying !== activePayload;
+      this.nowPlaying = activePayload;
+      if (changed) {
+        this.broadcast({ type: 'nowPlaying', payload: activePayload });
+        const useRemoteTimeline = store.get('player.useRemoteTimeline') === true;
+        if (useRemoteTimeline) {
+          const t = Number.isFinite(activePayload.progressSeconds)
+            ? activePayload.progressSeconds
+            : (Number.isFinite(activePayload.progressMs) ? activePayload.progressMs / 1000 : null);
+          if (t != null) {
+            this.broadcast({ type: 'setTime', payload: { t } });
+          }
+        }
+      }
+    } else if (this.activeSessionKey && !activePayload) {
+      this.nowPlaying = null;
+    }
+    this.emitRemoteSessions();
   }
   broadcast(obj) {
     const s = JSON.stringify(obj);

--- a/src/main/overlayServer.mjs
+++ b/src/main/overlayServer.mjs
@@ -33,6 +33,7 @@ const FONT_WEIGHT_PATTERNS = [
 const FONT_ITALIC_PATTERNS = [/\bitalic\b/gi, /\boblique\b/gi];
 const REMOTE_PROGRESS_EPSILON_SECONDS = 0.25;
 const REMOTE_STALL_TIME_MS = 1500;
+const REMOTE_SESSION_EXPIRY_MS = 10 * 60 * 1000;
 
 function mergeStyles(currentStyle, patchStyle) {
   const base = (currentStyle && typeof currentStyle === 'object') ? currentStyle : {};
@@ -291,6 +292,7 @@ export class OverlayServer {
     this.activeSessionKey = '';
     this.selectedSessionKey = '';
     this.nowPlaying = null;
+    this.remoteSessionSweepTimer = setInterval(() => this.sweepRemoteSessions(), 60 * 1000);
 
     this.app = express();
     this.server = http.createServer(this.app);
@@ -486,12 +488,71 @@ export class OverlayServer {
     return 'unknown';
   }
 
-  selectActiveSession({ preferSelected = true } = {}) {
+  getSessionActivityTimestamp(session) {
+    if (!session || typeof session !== 'object') return 0;
+    const update = Number(session.lastUpdate) || 0;
+    const seen = Number(session.lastSeen) || 0;
+    const play = Number(session.lastPlayTs) || 0;
+    return Math.max(update, seen, play);
+  }
+
+  isSessionExpired(session, now = Date.now()) {
+    if (!session || typeof session !== 'object') return true;
+    const ts = this.getSessionActivityTimestamp(session);
+    if (ts <= 0) return false;
+    return (now - ts) > REMOTE_SESSION_EXPIRY_MS;
+  }
+
+  pruneExpiredSessions({ now = Date.now() } = {}) {
+    let removed = false;
+    for (const [key, session] of this.remoteSessions) {
+      if (!this.isSessionExpired(session, now)) continue;
+      this.remoteSessions.delete(key);
+      if (this.activeSessionKey === key) {
+        this.activeSessionKey = '';
+        this.nowPlaying = null;
+      }
+      if (this.selectedSessionKey === key) {
+        this.selectedSessionKey = '';
+      }
+      removed = true;
+    }
+    return removed;
+  }
+
+  sweepRemoteSessions({ now = Date.now() } = {}) {
+    const removed = this.pruneExpiredSessions({ now });
+    if (!removed) return;
+    const previousActive = this.activeSessionKey;
+    const nextActive = this.selectActiveSession({ now });
+    this.activeSessionKey = nextActive;
+    if (nextActive) {
+      const activeSession = this.remoteSessions.get(nextActive) || null;
+      this.nowPlaying = activeSession?.nowPlaying || null;
+      if (this.nowPlaying && previousActive !== nextActive) {
+        this.broadcast({ type: 'nowPlaying', payload: this.nowPlaying });
+        const useRemoteTimeline = store.get('player.useRemoteTimeline') === true;
+        if (useRemoteTimeline) {
+          const t = Number.isFinite(this.nowPlaying.progressSeconds)
+            ? this.nowPlaying.progressSeconds
+            : (Number.isFinite(this.nowPlaying.progressMs) ? this.nowPlaying.progressMs / 1000 : null);
+          if (t != null) {
+            this.broadcast({ type: 'setTime', payload: { t } });
+          }
+        }
+      }
+    } else if (previousActive) {
+      this.nowPlaying = null;
+    }
+    this.emitRemoteSessions();
+  }
+
+  selectActiveSession({ preferSelected = true, now = Date.now() } = {}) {
     let selectedSession = null;
     if (this.selectedSessionKey) {
       selectedSession = this.remoteSessions.get(this.selectedSessionKey) || null;
-      const status = String(selectedSession?.status || '').toLowerCase();
-      if (!selectedSession || status === 'stopped') {
+      const expired = !selectedSession || this.isSessionExpired(selectedSession, now);
+      if (expired) {
         this.selectedSessionKey = '';
         selectedSession = null;
       }
@@ -503,8 +564,8 @@ export class OverlayServer {
     let activeSession = null;
     if (this.activeSessionKey) {
       activeSession = this.remoteSessions.get(this.activeSessionKey) || null;
-      const status = String(activeSession?.status || '').toLowerCase();
-      if (!activeSession || status === 'stopped') {
+      const expired = !activeSession || this.isSessionExpired(activeSession, now);
+      if (expired) {
         this.activeSessionKey = '';
         activeSession = null;
       }
@@ -513,7 +574,7 @@ export class OverlayServer {
     let bestTs = -1;
     for (const [key, session] of this.remoteSessions) {
       const status = String(session?.status || '').toLowerCase();
-      if (status === 'stopped') continue;
+      if (this.isSessionExpired(session, now)) continue;
       if (status === 'playing') {
         const ts = session.lastPlayTs ?? session.lastUpdate ?? 0;
         if (ts >= bestTs) {
@@ -528,14 +589,16 @@ export class OverlayServer {
     let fallbackTs = -1;
     for (const [key, session] of this.remoteSessions) {
       const status = String(session?.status || '').toLowerCase();
-      if (status === 'stopped') continue;
+      if (this.isSessionExpired(session, now)) continue;
       const ts = session.lastUpdate ?? 0;
       if (ts >= fallbackTs) {
         fallbackTs = ts;
         fallbackKey = key;
       }
     }
-    return fallbackKey;
+    if (fallbackKey) return fallbackKey;
+    if (this.selectedSessionKey && selectedSession) return this.selectedSessionKey;
+    return '';
   }
 
   updateNowPlaying(raw) {
@@ -567,6 +630,7 @@ export class OverlayServer {
     }
     session.nowPlaying = normalizedWithKey;
     session.lastUpdate = now;
+    session.lastSeen = now;
     session.status = String(normalizedWithKey.status || '').toLowerCase();
     if (session.status === 'playing' && previousStatus !== 'playing') {
       session.lastPlayTs = now;
@@ -597,15 +661,17 @@ export class OverlayServer {
     } else if (!this.activeSessionKey) {
       this.nowPlaying = null;
     }
-    const STALE_WINDOW = 5 * 60 * 1000;
-    for (const [key, sessionData] of this.remoteSessions) {
-      if (key === this.activeSessionKey) continue;
-      const age = now - (sessionData.lastUpdate ?? now);
-      if (age > STALE_WINDOW) this.remoteSessions.delete(key);
-    }
-    if (this.activeSessionKey && !this.remoteSessions.has(this.activeSessionKey)) {
-      this.activeSessionKey = '';
-      this.nowPlaying = null;
+    const removed = this.pruneExpiredSessions({ now });
+    if ((!this.activeSessionKey || !this.remoteSessions.has(this.activeSessionKey)) && this.remoteSessions.size) {
+      const nextKey = this.selectActiveSession({ now });
+      if (nextKey) {
+        this.activeSessionKey = nextKey;
+        const nextSession = this.remoteSessions.get(nextKey) || null;
+        this.nowPlaying = nextSession?.nowPlaying || null;
+      } else if (!removed) {
+        this.activeSessionKey = '';
+        this.nowPlaying = null;
+      }
     }
     if (this.selectedSessionKey && !this.remoteSessions.has(this.selectedSessionKey)) {
       this.selectedSessionKey = '';
@@ -613,10 +679,11 @@ export class OverlayServer {
     this.emitRemoteSessions();
   }
   buildRemoteSessionsPayload() {
+    const now = Date.now();
     const sessions = [];
     for (const [key, session] of this.remoteSessions) {
+      if (this.isSessionExpired(session, now)) continue;
       const status = String(session?.status || '').toLowerCase();
-      if (status === 'stopped') continue;
       const info = session?.nowPlaying || null;
       sessions.push({
         key,
@@ -624,6 +691,7 @@ export class OverlayServer {
         status: session?.status || 'unknown',
         lastUpdate: session?.lastUpdate || 0,
         lastPlayTs: session?.lastPlayTs || 0,
+        lastSeen: session?.lastSeen || 0,
         connected: session?.connected !== false,
         guid: session?.guid || info?.guid || '',
         nowPlaying: info ? {
@@ -686,14 +754,14 @@ export class OverlayServer {
   setActiveSessionKey(key) {
     const normalized = typeof key === 'string' ? key.trim() : '';
     const session = normalized ? this.remoteSessions.get(normalized) : null;
-    const status = String(session?.status || '').toLowerCase();
-    const exists = Boolean(normalized && session && status !== 'stopped');
+    const now = Date.now();
+    const exists = Boolean(normalized && session && !this.isSessionExpired(session, now));
     this.selectedSessionKey = exists ? normalized : '';
     const previousActive = this.activeSessionKey;
     if (exists) {
       this.activeSessionKey = normalized;
     } else {
-      this.activeSessionKey = this.selectActiveSession({ preferSelected: false });
+      this.activeSessionKey = this.selectActiveSession({ preferSelected: false, now });
     }
     const activeSession = this.activeSessionKey ? this.remoteSessions.get(this.activeSessionKey) : null;
     const activePayload = activeSession?.nowPlaying || null;
@@ -824,6 +892,10 @@ export class OverlayServer {
     // once the underlying HTTP server is closed.
     return new Promise((resolve) => {
       try {
+        if (this.remoteSessionSweepTimer) {
+          clearInterval(this.remoteSessionSweepTimer);
+          this.remoteSessionSweepTimer = null;
+        }
         if (this.wss) {
           try { this.wss.close(); } catch (err) { /* swallow */ }
         }

--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -753,6 +753,7 @@ const state = {
   remoteLastUpdate: 0,
   remoteMediaKey: '',
   remoteProgressTimer: null,
+  remoteSessionNowPlaying: new Map(),
   remoteCoverObjectUrl: '',
   remoteCoverSource: '',
   remoteCoverAbort: null,
@@ -1008,6 +1009,88 @@ function getRemoteProgressSeconds(info) {
   return null;
 }
 
+function upsertRemoteSessionSnapshot(sessionKey, payload) {
+  const key = sanitizeRemoteIdentity(sessionKey || payload?.sessionKey);
+  if (!key || !payload || typeof payload !== 'object') return { key: '', entry: null };
+  let entry = state.remoteSessionNowPlaying.get(key) || null;
+  if (entry && entry !== payload) {
+    Object.assign(entry, payload, { sessionKey: key });
+  } else if (!entry) {
+    entry = payload;
+    entry.sessionKey = key;
+    state.remoteSessionNowPlaying.set(key, entry);
+  }
+  return { key, entry };
+}
+
+function pruneRemoteSessionSnapshots(validKeys = []) {
+  if (!Array.isArray(validKeys) || !validKeys.length) return;
+  const allow = new Set(validKeys.map((key) => sanitizeRemoteIdentity(key)).filter(Boolean));
+  if (!allow.size) return;
+  for (const key of Array.from(state.remoteSessionNowPlaying.keys())) {
+    if (allow.has(key)) continue;
+    state.remoteSessionNowPlaying.delete(key);
+  }
+}
+
+function commitRemoteNowPlaying(payload, { derivedKeyHint = '' } = {}) {
+  if (!payload || typeof payload !== 'object') return;
+  const info = payload;
+  const payloadSessionKey = sanitizeRemoteIdentity(info.sessionKey);
+  const previousInfo = state.remoteNowPlaying;
+  const previousSessionKey = sanitizeRemoteIdentity(previousInfo?.sessionKey);
+  const previousKeyDerived = previousInfo ? getRemoteMediaKey(previousInfo) : '';
+  const derivedKey = derivedKeyHint || getRemoteMediaKey(info) || '';
+  const sameEntry = areSameRemoteEntries(
+    previousInfo,
+    info,
+    previousSessionKey || previousKeyDerived,
+    payloadSessionKey || derivedKey
+  );
+  const previousReceivedAt = Number(previousInfo?.receivedAt) || state.remoteLastUpdate || 0;
+  const nextReceivedAt = Number(info.receivedAt) || Date.now();
+  if (
+    sameEntry &&
+    info.status === 'playing'
+  ) {
+    const previousProgress = getRemoteProgressSeconds(previousInfo);
+    const nextProgress = getRemoteProgressSeconds(info);
+    const elapsedMs = previousReceivedAt > 0 ? Math.max(0, nextReceivedAt - previousReceivedAt) : 0;
+    if (
+      previousProgress != null &&
+      nextProgress != null &&
+      elapsedMs >= REMOTE_STALL_TIME_MS &&
+      Math.abs(nextProgress - previousProgress) <= REMOTE_TIME_EPSILON
+    ) {
+      info.status = 'paused';
+    }
+  }
+  state.remoteNowPlaying = info;
+  if (info.guid) state.remoteLastGuid = info.guid;
+  state.remoteLastUpdate = Number.isFinite(info.receivedAt)
+    ? info.receivedAt
+    : Date.now();
+  const previousKey = state.remoteMediaKey || '';
+  if (derivedKey) state.remoteMediaKey = derivedKey;
+  if (state.useRemoteTimeline) {
+    const keyChanged = derivedKey && derivedKey !== previousKey;
+    applyRemoteTimeline(info);
+    if (keyChanged && state.activeSubsId) {
+      applySubtitleOffsetForSelection({ subsId: state.activeSubsId, notify: true });
+    }
+    applyRemoteMediaUiState();
+    updateVideoCacheSelect(state.remoteSelectedKey || state.remoteActiveSessionKey);
+  }
+  updateRemotePlayerUi(info);
+  const effectiveStatus = getRemotePlaybackStatus(info);
+  if (state.useRemoteTimeline && effectiveStatus === 'playing') {
+    startRemoteProgressTimer();
+  } else {
+    stopRemoteProgressTimer();
+  }
+  updateActiveCacheInfo();
+}
+
 function sanitizeRemoteIdentity(value, { lower = false } = {}) {
   if (typeof value !== 'string') return '';
   const trimmed = value.trim();
@@ -1039,66 +1122,32 @@ function areSameRemoteEntries(prev, next, prevKey = '', nextKey = '') {
 }
 
 function handleRemoteNowPlaying(raw) {
-  const previousInfo = state.remoteNowPlaying;
   const payload = normalizeNowPlayingPayload(raw);
   if (!payload) return;
-  const payloadSessionKey = sanitizeRemoteIdentity(payload.sessionKey);
-  if (payloadSessionKey) {
-    payload.sessionKey = payloadSessionKey;
-  }
   const selectedSessionKey = sanitizeRemoteIdentity(state.remoteSelectedKey);
-  if (selectedSessionKey && payloadSessionKey && selectedSessionKey !== payloadSessionKey) {
+  const activeSessionKey = sanitizeRemoteIdentity(state.remoteActiveSessionKey);
+  const payloadSessionKey = sanitizeRemoteIdentity(payload.sessionKey);
+  const derivedKey = getRemoteMediaKey(payload) || '';
+  let canonicalKey = payloadSessionKey || derivedKey || '';
+  let snapshot = payload;
+  if (canonicalKey) {
+    payload.sessionKey = canonicalKey;
+    const { key: storedKey, entry } = upsertRemoteSessionSnapshot(canonicalKey, payload);
+    if (storedKey) canonicalKey = storedKey;
+    if (entry) snapshot = entry;
+  }
+  let trackedSessionKey = selectedSessionKey || activeSessionKey;
+  if (!selectedSessionKey && canonicalKey && (!activeSessionKey || activeSessionKey === canonicalKey)) {
+    state.remoteActiveSessionKey = canonicalKey;
+    trackedSessionKey = canonicalKey;
+    if (state.useRemoteTimeline) {
+      updateVideoCacheSelect(canonicalKey);
+    }
+  }
+  if (trackedSessionKey && canonicalKey && trackedSessionKey !== canonicalKey) {
     return;
   }
-  if (!selectedSessionKey && payloadSessionKey && sanitizeRemoteIdentity(state.remoteActiveSessionKey) !== payloadSessionKey) {
-    state.remoteActiveSessionKey = payloadSessionKey;
-    if (state.useRemoteTimeline) {
-      updateVideoCacheSelect(payloadSessionKey);
-    }
-  }
-  const previousKeyDerived = previousInfo ? getRemoteMediaKey(previousInfo) : '';
-  const derivedKey = getRemoteMediaKey(payload) || '';
-  const previousSessionKey = sanitizeRemoteIdentity(previousInfo?.sessionKey);
-  const sameEntry = areSameRemoteEntries(previousInfo, payload, previousSessionKey || previousKeyDerived, payloadSessionKey || derivedKey);
-  const previousReceivedAt = Number(previousInfo?.receivedAt) || state.remoteLastUpdate || 0;
-  const nextReceivedAt = Number(payload.receivedAt) || Date.now();
-  if (sameEntry && payload.status === 'playing') {
-    const previousProgress = getRemoteProgressSeconds(previousInfo);
-    const nextProgress = getRemoteProgressSeconds(payload);
-    const elapsedMs = previousReceivedAt > 0 ? Math.max(0, nextReceivedAt - previousReceivedAt) : 0;
-    if (
-      previousProgress != null &&
-      nextProgress != null &&
-      elapsedMs >= REMOTE_STALL_TIME_MS &&
-      Math.abs(nextProgress - previousProgress) <= REMOTE_TIME_EPSILON
-    ) {
-      payload.status = 'paused';
-    }
-  }
-  state.remoteNowPlaying = payload;
-  if (payload.guid) state.remoteLastGuid = payload.guid;
-  state.remoteLastUpdate = Number.isFinite(payload.receivedAt)
-    ? payload.receivedAt
-    : Date.now();
-  const previousKey = state.remoteMediaKey || '';
-  if (derivedKey) state.remoteMediaKey = derivedKey;
-  if (state.useRemoteTimeline) {
-    const keyChanged = derivedKey && derivedKey !== previousKey;
-    applyRemoteTimeline(payload);
-    if (keyChanged && state.activeSubsId) {
-      applySubtitleOffsetForSelection({ subsId: state.activeSubsId, notify: true });
-    }
-    applyRemoteMediaUiState();
-    updateVideoCacheSelect(state.remoteSelectedKey || state.remoteActiveSessionKey);
-  }
-  updateRemotePlayerUi(payload);
-  const effectiveStatus = getRemotePlaybackStatus(payload);
-  if (state.useRemoteTimeline && effectiveStatus === 'playing') {
-    startRemoteProgressTimer();
-  } else {
-    stopRemoteProgressTimer();
-  }
-  updateActiveCacheInfo();
+  commitRemoteNowPlaying(snapshot, { derivedKeyHint: derivedKey });
 }
 
 function handleRemoteSessionsUpdate(payload = {}) {
@@ -1130,9 +1179,52 @@ function handleRemoteSessionsUpdate(payload = {}) {
   const selectedKey = typeof payload.selectedKey === 'string' ? payload.selectedKey : '';
   state.remoteActiveSessionKey = normalized.some((session) => session.key === activeKey) ? activeKey : '';
   state.remoteSelectedKey = normalized.some((session) => session.key === selectedKey) ? selectedKey : '';
+  if (!normalized.length) {
+    state.remoteSessionNowPlaying.clear();
+  } else {
+    const allowedKeys = [];
+    for (const session of normalized) {
+      allowedKeys.push(session.key);
+      if (session.nowPlaying?.sessionKey) {
+        allowedKeys.push(session.nowPlaying.sessionKey);
+      }
+    }
+    pruneRemoteSessionSnapshots(allowedKeys);
+    for (const session of normalized) {
+      if (!session.nowPlaying) continue;
+      const snapshot = normalizeNowPlayingPayload({
+        sessionKey: session.nowPlaying.sessionKey || session.key,
+        status: session.nowPlaying.status,
+        title: session.nowPlaying.title,
+        artists: session.nowPlaying.artists,
+        progressMs: session.nowPlaying.progressMs ?? (Number.isFinite(session.nowPlaying.progressSeconds)
+          ? session.nowPlaying.progressSeconds * 1000
+          : undefined),
+        durationMs: session.nowPlaying.durationMs ?? (Number.isFinite(session.nowPlaying.durationSeconds)
+          ? session.nowPlaying.durationSeconds * 1000
+          : undefined),
+        song_link: session.nowPlaying.songLink,
+        platform: session.nowPlaying.platform,
+        is_live: session.nowPlaying.isLive,
+        guid: session.nowPlaying.guid || session.guid || ''
+      });
+      if (!snapshot) continue;
+      snapshot.receivedAt = Number.isFinite(session.nowPlaying.receivedAt)
+        ? session.nowPlaying.receivedAt
+        : (Number.isFinite(session.lastUpdate) ? session.lastUpdate : Date.now());
+      upsertRemoteSessionSnapshot(session.nowPlaying.sessionKey || session.key, snapshot);
+    }
+  }
   if (state.useRemoteTimeline) {
     const targetKey = state.remoteSelectedKey || state.remoteActiveSessionKey || '';
     updateVideoCacheSelect(targetKey);
+  }
+  const trackedKey = sanitizeRemoteIdentity(state.remoteSelectedKey || state.remoteActiveSessionKey);
+  if (trackedKey) {
+    const snapshot = state.remoteSessionNowPlaying.get(trackedKey);
+    if (snapshot) {
+      commitRemoteNowPlaying(snapshot);
+    }
   }
 }
 
@@ -2721,6 +2813,11 @@ function normalizeRemoteSession(raw) {
     const artists = Array.isArray(raw.nowPlaying.artists)
       ? raw.nowPlaying.artists.map((name) => (typeof name === 'string' ? name.trim() : '')).filter(Boolean)
       : [];
+    const progressMsRaw = Number(raw.nowPlaying.progressMs ?? raw.nowPlaying.progress_ms);
+    const progressSecondsRaw = Number(raw.nowPlaying.progressSeconds ?? raw.nowPlaying.progress_seconds);
+    const durationMsRaw = Number(raw.nowPlaying.durationMs ?? raw.nowPlaying.duration_ms);
+    const durationSecondsRaw = Number(raw.nowPlaying.durationSeconds ?? raw.nowPlaying.duration_seconds);
+    const receivedAtRaw = Number(raw.nowPlaying.receivedAt ?? raw.lastUpdate ?? 0);
     nowPlaying = {
       sessionKey: rawSessionKey ? rawSessionKey.trim() : key,
       title: typeof raw.nowPlaying.title === 'string' ? raw.nowPlaying.title : '',
@@ -2730,7 +2827,17 @@ function normalizeRemoteSession(raw) {
         : status,
       songLink: typeof raw.nowPlaying.songLink === 'string' ? raw.nowPlaying.songLink : '',
       platform: typeof raw.nowPlaying.platform === 'string' ? raw.nowPlaying.platform : '',
-      isLive: raw.nowPlaying.isLive === true
+      isLive: raw.nowPlaying.isLive === true,
+      progressMs: Number.isFinite(progressMsRaw) ? Math.max(0, progressMsRaw) : null,
+      progressSeconds: Number.isFinite(progressSecondsRaw)
+        ? Math.max(0, progressSecondsRaw)
+        : (Number.isFinite(progressMsRaw) ? Math.max(0, progressMsRaw / 1000) : null),
+      durationMs: Number.isFinite(durationMsRaw) ? Math.max(0, durationMsRaw) : null,
+      durationSeconds: Number.isFinite(durationSecondsRaw)
+        ? Math.max(0, durationSecondsRaw)
+        : (Number.isFinite(durationMsRaw) ? Math.max(0, durationMsRaw / 1000) : null),
+      receivedAt: Number.isFinite(receivedAtRaw) ? receivedAtRaw : 0,
+      guid: typeof raw.nowPlaying.guid === 'string' ? raw.nowPlaying.guid.trim() : ''
     };
   }
   const resolvedStatus = (nowPlaying?.status || status || 'unknown').toLowerCase();
@@ -2850,6 +2957,10 @@ function handleVideoCacheSelectChange() {
   if (state.useRemoteTimeline) {
     state.remoteSelectedKey = id;
     overlaySync.setActiveSessionKey(id);
+    const snapshot = state.remoteSessionNowPlaying.get(sanitizeRemoteIdentity(id));
+    if (snapshot) {
+      commitRemoteNowPlaying(snapshot);
+    }
     refreshCustomSelect(dom.videoCacheSelect);
     return;
   }

--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -736,6 +736,9 @@ const state = {
   activeSubsId: '',
   videoSearch: '',
   subsSearch: '',
+  remoteSessions: [],
+  remoteSelectedKey: '',
+  remoteActiveSessionKey: '',
   objectUrl: '',
   binProgress: new Map(),
   binInfoRefreshTimer: null,
@@ -834,6 +837,8 @@ class OverlaySync {
     this.video = videoEl;
     this.pendingTime = null;
     this.nowPlayingHandler = null;
+    this.remoteSessionsHandler = null;
+    this.pendingSessionKey = null;
 
     this.handleWsOpen = this.handleWsOpen.bind(this);
     this.handleWsClose = this.handleWsClose.bind(this);
@@ -842,6 +847,9 @@ class OverlaySync {
   }
   setNowPlayingHandler(handler) {
     this.nowPlayingHandler = typeof handler === 'function' ? handler : null;
+  }
+  setRemoteSessionsHandler(handler) {
+    this.remoteSessionsHandler = typeof handler === 'function' ? handler : null;
   }
   connect(port) {
     const parsed = Number.parseInt(port, 10);
@@ -882,6 +890,11 @@ class OverlaySync {
       this.pendingTime = null;
       this.sendTime(time);
     }
+    if (this.pendingSessionKey != null) {
+      const key = this.pendingSessionKey;
+      this.pendingSessionKey = null;
+      this.setActiveSessionKey(key);
+    }
   }
   handleWsClose(event) {
     if (event?.target) this.detachWs(event.target);
@@ -893,14 +906,17 @@ class OverlaySync {
     // suppress connection errors to keep renderer logs quiet
   }
   handleWsMessage(event) {
-    if (!this.nowPlayingHandler || !event?.data) return;
+    if (!event?.data) return;
     let data;
     try { data = JSON.parse(event.data); } catch { return; }
     if (!data || typeof data !== 'object') return;
     if (data.type === 'nowPlaying' && data.payload) {
-      this.nowPlayingHandler(data.payload);
+      this.nowPlayingHandler?.(data.payload);
+    } else if (data.type === 'remoteSessions') {
+      const payload = data.payload && typeof data.payload === 'object' ? data.payload : {};
+      this.remoteSessionsHandler?.(payload);
     } else if (!data.type && looksLikeNowPlayingPayload(data)) {
-      this.nowPlayingHandler(data);
+      this.nowPlayingHandler?.(data);
     }
   }
   start() {
@@ -925,11 +941,24 @@ class OverlaySync {
       this.pendingTime = time;
     }
   }
+  setActiveSessionKey(key) {
+    const normalized = typeof key === 'string' ? key : '';
+    const ws = this.ws;
+    const message = JSON.stringify({ type: 'setActiveSession', payload: { key: normalized } });
+    if (ws && ws.readyState === 1) {
+      try { ws.send(message); } catch { /* noop */ }
+      this.pendingSessionKey = null;
+    } else {
+      this.pendingSessionKey = normalized;
+    }
+  }
 }
 
 const overlaySync = new OverlaySync(dom.video);
 overlaySync.setNowPlayingHandler(handleRemoteNowPlaying);
+overlaySync.setRemoteSessionsHandler(handleRemoteSessionsUpdate);
 const REMOTE_TIME_EPSILON = 0.25;
+const REMOTE_STALL_TIME_MS = 1500;
 
 function looksLikeNowPlayingPayload(raw) {
   if (!raw || typeof raw !== 'object') return false;
@@ -955,6 +984,7 @@ function normalizeNowPlayingPayload(raw) {
     ? raw.artists.map((name) => normalizeStr(name)).filter(Boolean)
     : [];
   return {
+    sessionKey: normalizeStr(raw.sessionKey || raw.session_key),
     guid: normalizeStr(raw.guid),
     cover: normalizeStr(raw.cover),
     title: normalizeStr(raw.title),
@@ -971,13 +1001,85 @@ function normalizeNowPlayingPayload(raw) {
   };
 }
 
+function getRemoteProgressSeconds(info) {
+  if (!info || typeof info !== 'object') return null;
+  if (Number.isFinite(info.progressSeconds)) return Math.max(0, info.progressSeconds);
+  if (Number.isFinite(info.progressMs)) return Math.max(0, info.progressMs / 1000);
+  return null;
+}
+
+function sanitizeRemoteIdentity(value, { lower = false } = {}) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return lower ? trimmed.toLowerCase() : trimmed;
+}
+
+function areSameRemoteEntries(prev, next, prevKey = '', nextKey = '') {
+  if (!prev || !next || typeof prev !== 'object' || typeof next !== 'object') return false;
+  if (prevKey && nextKey) return prevKey === nextKey;
+  const prevGuid = sanitizeRemoteIdentity(prev.guid);
+  const nextGuid = sanitizeRemoteIdentity(next.guid);
+  if (prevGuid && nextGuid) return prevGuid === nextGuid;
+  const prevSong = sanitizeRemoteIdentity(prev.songLink);
+  const nextSong = sanitizeRemoteIdentity(next.songLink);
+  if (prevSong && nextSong) return prevSong === nextSong;
+  const prevTitle = sanitizeRemoteIdentity(prev.title, { lower: true });
+  const nextTitle = sanitizeRemoteIdentity(next.title, { lower: true });
+  if (!prevTitle || !nextTitle || prevTitle !== nextTitle) return false;
+  const prevPlatform = sanitizeRemoteIdentity(prev.platform, { lower: true });
+  const nextPlatform = sanitizeRemoteIdentity(next.platform, { lower: true });
+  if (prevPlatform && nextPlatform && prevPlatform !== nextPlatform) return false;
+  const joinArtists = (artists) => Array.isArray(artists)
+    ? artists.map((name) => sanitizeRemoteIdentity(name, { lower: true })).filter(Boolean).join('|')
+    : '';
+  const prevArtists = joinArtists(prev.artists);
+  const nextArtists = joinArtists(next.artists);
+  if (prevArtists && nextArtists) return prevArtists === nextArtists;
+  return true;
+}
+
 function handleRemoteNowPlaying(raw) {
+  const previousInfo = state.remoteNowPlaying;
   const payload = normalizeNowPlayingPayload(raw);
   if (!payload) return;
+  const payloadSessionKey = sanitizeRemoteIdentity(payload.sessionKey);
+  if (payloadSessionKey) {
+    payload.sessionKey = payloadSessionKey;
+  }
+  const selectedSessionKey = sanitizeRemoteIdentity(state.remoteSelectedKey);
+  if (selectedSessionKey && payloadSessionKey && selectedSessionKey !== payloadSessionKey) {
+    return;
+  }
+  if (!selectedSessionKey && payloadSessionKey && sanitizeRemoteIdentity(state.remoteActiveSessionKey) !== payloadSessionKey) {
+    state.remoteActiveSessionKey = payloadSessionKey;
+    if (state.useRemoteTimeline) {
+      updateVideoCacheSelect(payloadSessionKey);
+    }
+  }
+  const previousKeyDerived = previousInfo ? getRemoteMediaKey(previousInfo) : '';
+  const derivedKey = getRemoteMediaKey(payload) || '';
+  const previousSessionKey = sanitizeRemoteIdentity(previousInfo?.sessionKey);
+  const sameEntry = areSameRemoteEntries(previousInfo, payload, previousSessionKey || previousKeyDerived, payloadSessionKey || derivedKey);
+  const previousReceivedAt = Number(previousInfo?.receivedAt) || state.remoteLastUpdate || 0;
+  const nextReceivedAt = Number(payload.receivedAt) || Date.now();
+  if (sameEntry && payload.status === 'playing') {
+    const previousProgress = getRemoteProgressSeconds(previousInfo);
+    const nextProgress = getRemoteProgressSeconds(payload);
+    const elapsedMs = previousReceivedAt > 0 ? Math.max(0, nextReceivedAt - previousReceivedAt) : 0;
+    if (
+      previousProgress != null &&
+      nextProgress != null &&
+      elapsedMs >= REMOTE_STALL_TIME_MS &&
+      Math.abs(nextProgress - previousProgress) <= REMOTE_TIME_EPSILON
+    ) {
+      payload.status = 'paused';
+    }
+  }
   state.remoteNowPlaying = payload;
   if (payload.guid) state.remoteLastGuid = payload.guid;
-  state.remoteLastUpdate = payload.receivedAt;
-  const derivedKey = getRemoteMediaKey(payload) || '';
+  state.remoteLastUpdate = Number.isFinite(payload.receivedAt)
+    ? payload.receivedAt
+    : Date.now();
   const previousKey = state.remoteMediaKey || '';
   if (derivedKey) state.remoteMediaKey = derivedKey;
   if (state.useRemoteTimeline) {
@@ -987,20 +1089,57 @@ function handleRemoteNowPlaying(raw) {
       applySubtitleOffsetForSelection({ subsId: state.activeSubsId, notify: true });
     }
     applyRemoteMediaUiState();
-    updateVideoCacheSelect(state.activeVideoId);
-    updateRemotePlayerUi(payload);
+    updateVideoCacheSelect(state.remoteSelectedKey || state.remoteActiveSessionKey);
+  }
+  updateRemotePlayerUi(payload);
+  const effectiveStatus = getRemotePlaybackStatus(payload);
+  if (state.useRemoteTimeline && effectiveStatus === 'playing') {
     startRemoteProgressTimer();
   } else {
-    updateRemotePlayerUi(payload);
     stopRemoteProgressTimer();
   }
   updateActiveCacheInfo();
 }
 
+function handleRemoteSessionsUpdate(payload = {}) {
+  const sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
+  const normalized = [];
+  for (const item of sessions) {
+    const entry = normalizeRemoteSession(item);
+    if (entry) normalized.push(entry);
+  }
+  normalized.sort((a, b) => {
+    const playA = Number(a?.lastPlayTs) || 0;
+    const playB = Number(b?.lastPlayTs) || 0;
+    if (playA !== playB) return playB - playA;
+    const updateA = Number(a?.lastUpdate) || 0;
+    const updateB = Number(b?.lastUpdate) || 0;
+    if (updateA !== updateB) return updateB - updateA;
+    const statusA = (a?.status || '').toLowerCase();
+    const statusB = (b?.status || '').toLowerCase();
+    if (statusA !== statusB) {
+      const rank = { playing: 2, paused: 1 };
+      const scoreA = rank[statusA] || 0;
+      const scoreB = rank[statusB] || 0;
+      if (scoreA !== scoreB) return scoreB - scoreA;
+    }
+    return a.key.localeCompare(b.key);
+  });
+  state.remoteSessions = normalized;
+  const activeKey = typeof payload.activeKey === 'string' ? payload.activeKey : '';
+  const selectedKey = typeof payload.selectedKey === 'string' ? payload.selectedKey : '';
+  state.remoteActiveSessionKey = normalized.some((session) => session.key === activeKey) ? activeKey : '';
+  state.remoteSelectedKey = normalized.some((session) => session.key === selectedKey) ? selectedKey : '';
+  if (state.useRemoteTimeline) {
+    const targetKey = state.remoteSelectedKey || state.remoteActiveSessionKey || '';
+    updateVideoCacheSelect(targetKey);
+  }
+}
+
 function applyRemoteTimeline(payload) {
   if (!payload) return;
   if (!dom.video) return;
-  const status = String(payload.status || '').toLowerCase();
+  const status = getRemotePlaybackStatus(payload);
   dom.video.dataset.remoteStatus = status || 'unknown';
   dom.video.classList.toggle('is-remote-playing', status === 'playing');
   dom.video.classList.toggle('is-remote-paused', status === 'paused');
@@ -1047,6 +1186,32 @@ function formatClockTime(seconds) {
   return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
 }
 
+function getRemotePayloadTimestamp(info = state.remoteNowPlaying) {
+  if (info && Number.isFinite(info.receivedAt)) return info.receivedAt;
+  if (info === state.remoteNowPlaying && Number.isFinite(state.remoteLastUpdate)) {
+    return state.remoteLastUpdate;
+  }
+  return 0;
+}
+
+function getRemotePlaybackStatus(info = state.remoteNowPlaying) {
+  if (!info || typeof info !== 'object') return 'unknown';
+  const status = String(info.status || '').toLowerCase();
+  if (status === 'playing') {
+    const receivedAt = getRemotePayloadTimestamp(info);
+    if (receivedAt > 0) {
+      const staleFor = Date.now() - receivedAt;
+      if (staleFor >= REMOTE_STALL_TIME_MS) {
+        return 'paused';
+      }
+    }
+    return 'playing';
+  }
+  if (status === 'paused') return 'paused';
+  if (status === 'stopped') return 'stopped';
+  return status || 'unknown';
+}
+
 function getRemoteProgressEstimate(info = state.remoteNowPlaying) {
   if (!info || typeof info !== 'object') {
     return { progress: null, duration: null };
@@ -1058,9 +1223,9 @@ function getRemoteProgressEstimate(info = state.remoteNowPlaying) {
     ? Math.max(0, info.durationSeconds)
     : (Number.isFinite(info.durationMs) ? Math.max(0, info.durationMs / 1000) : null);
   let progress = progressBase != null ? Math.max(0, progressBase) : null;
-  const status = String(info.status || '').toLowerCase();
-  const baseTs = Number.isFinite(info.receivedAt) ? info.receivedAt : state.remoteLastUpdate || Date.now();
-  if (progress != null && status === 'playing') {
+  const status = getRemotePlaybackStatus(info);
+  const baseTs = getRemotePayloadTimestamp(info);
+  if (progress != null && status === 'playing' && baseTs > 0) {
     const elapsed = Math.max(0, (Date.now() - baseTs) / 1000);
     progress += elapsed;
   }
@@ -1093,7 +1258,7 @@ function updateRemoteProgressDisplay(info = state.remoteNowPlaying) {
 
 function getRemoteStatusLabel(info = state.remoteNowPlaying) {
   if (!info || typeof info !== 'object') return '等待播放';
-  const status = String(info.status || '').toLowerCase();
+  const status = getRemotePlaybackStatus(info);
   const isLive = info.isLive === true;
   if (status === 'playing') return isLive ? '直播中' : '播放中';
   if (status === 'paused') return isLive ? '直播暫停' : '已暫停';
@@ -1123,7 +1288,7 @@ function updateRemotePlayerUi(info = state.remoteNowPlaying) {
     applyRemoteCoverImage(remote?.cover || '');
   }
 
-  const status = String(remote?.status || '').toLowerCase();
+  const status = getRemotePlaybackStatus(remote);
   dom.remoteHud.classList.toggle('is-playing', status === 'playing');
   dom.remoteHud.classList.toggle('is-paused', status === 'paused');
   dom.remoteHud.classList.toggle('is-stopped', !status || status === 'stopped');
@@ -1140,6 +1305,13 @@ function startRemoteProgressTimer() {
       return;
     }
     updateRemoteProgressDisplay();
+    if (getRemotePlaybackStatus() !== 'playing') {
+      if (state.useRemoteTimeline && state.remoteNowPlaying) {
+        applyRemoteTimeline(state.remoteNowPlaying);
+      }
+      updateRemotePlayerUi();
+      stopRemoteProgressTimer();
+    }
   }, 500);
 }
 
@@ -1227,20 +1399,21 @@ function updateRemoteToggleUI() {
   dom.useRemoteTimelineToggle.setAttribute('aria-checked', state.useRemoteTimeline ? 'true' : 'false');
 }
 
-function getRemoteMediaLabel(remote = state.remoteNowPlaying) {
-  if (!remote || typeof remote !== 'object') return '外部時間軸已啟用';
-  const parts = [];
-  if (remote.title) parts.push(remote.title);
-  if (Array.isArray(remote.artists) && remote.artists.length) parts.push(remote.artists.join(', '));
-  if (!parts.length && remote.platform) parts.push(remote.platform);
-  return parts.length ? parts.join(' - ') : '外部時間軸已啟用';
-}
-
 function applyRemoteMediaUiState() {
   const usingRemote = Boolean(state.useRemoteTimeline);
   if (dom.videoCacheSearch) {
-    dom.videoCacheSearch.disabled = usingRemote;
-    dom.videoCacheSearch.classList.toggle('is-remote-disabled', usingRemote);
+    const input = dom.videoCacheSearch;
+    input.disabled = false;
+    input.classList.toggle('is-remote-disabled', usingRemote);
+    if (!input.dataset.placeholderVideo) {
+      input.dataset.placeholderVideo = input.placeholder || '';
+    }
+    if (!input.dataset.placeholderRemote) {
+      input.dataset.placeholderRemote = '搜尋外部播放來源...';
+    }
+    input.placeholder = usingRemote
+      ? input.dataset.placeholderRemote
+      : (input.dataset.placeholderVideo || '');
   }
   if (dom.pickVideo) {
     dom.pickVideo.disabled = usingRemote;
@@ -1249,38 +1422,6 @@ function applyRemoteMediaUiState() {
   const select = dom.videoCacheSelect;
   if (!select) return;
   select.classList.toggle('is-remote-disabled', usingRemote);
-  if (usingRemote) {
-    const label = getRemoteMediaLabel();
-    const previousLabel = select.dataset.remoteLabel || '';
-    const hasSingleOption = select.options.length === 1;
-    const currentOption = hasSingleOption ? select.options[0] : null;
-    const needsRebuild =
-      !currentOption ||
-      currentOption.value !== '' ||
-      currentOption.disabled !== true ||
-      currentOption.textContent !== label;
-
-    select.disabled = true;
-
-    if (needsRebuild) {
-      select.innerHTML = '';
-      const option = new Option(label, '', true, true);
-      option.disabled = true;
-      select.add(option);
-      refreshCustomSelect(select, { rebuildOptions: true });
-    } else if (previousLabel !== label) {
-      refreshCustomSelect(select, { rebuildOptions: true });
-    }
-
-    if (select.dataset.remoteLabel !== label) {
-      select.dataset.remoteLabel = label;
-    }
-  } else {
-    select.disabled = false;
-    if (select.dataset.remoteLabel) {
-      delete select.dataset.remoteLabel;
-    }
-  }
 }
 
 function setRemoteTimelineEnabled(enabled, { persist = false } = {}) {
@@ -1307,12 +1448,20 @@ function setRemoteTimelineEnabled(enabled, { persist = false } = {}) {
   updateRemotePlayerVisibility();
   if (state.useRemoteTimeline) {
     updateRemotePlayerUi();
-    startRemoteProgressTimer();
+    if (getRemotePlaybackStatus() === 'playing') {
+      startRemoteProgressTimer();
+    } else {
+      stopRemoteProgressTimer();
+    }
   } else {
     stopRemoteProgressTimer();
     updateRemotePlayerUi();
   }
-  updateVideoCacheSelect(state.activeVideoId);
+  if (state.useRemoteTimeline) {
+    updateVideoCacheSelect(state.remoteSelectedKey || state.remoteActiveSessionKey);
+  } else {
+    updateVideoCacheSelect(state.activeVideoId);
+  }
   const canApplyOffset = state.activeSubsId && (!state.useRemoteTimeline || state.remoteMediaKey);
   if (canApplyOffset) {
     applySubtitleOffsetForSelection({ videoId: state.activeVideoId, subsId: state.activeSubsId });
@@ -2387,7 +2536,9 @@ async function handleDownloadDone(payload) {
     const merged = upsertCacheEntry(entry);
     let activeVideoEntry = getEntryById(state.activeVideoId);
     let activeSubsEntry = getEntryById(state.activeSubsId);
-    if (merged?.hasVideo && merged.videoFilename) {
+    if (state.useRemoteTimeline) {
+      updateVideoCacheSelect(state.remoteSelectedKey || state.remoteActiveSessionKey);
+    } else if (merged?.hasVideo && merged.videoFilename) {
       state.activeVideoId = merged.id;
       updateVideoCacheSelect(merged.id);
       await loadVideoEntry(merged);
@@ -2475,16 +2626,27 @@ function formatSubtitleOptionLabel(entry) {
   return `${base}（${markers.join(' / ')}）`;
 }
 
-function updateVideoCacheSelect(selectedId = state.activeVideoId) {
+function updateVideoCacheSelect(selectedId) {
   const select = dom.videoCacheSelect;
   if (!select) return;
   applyRemoteMediaUiState();
-  if (state.useRemoteTimeline) return;
+  if (state.useRemoteTimeline) {
+    const searchTerm = (state.videoSearch || '').toLowerCase();
+    const targetKey = typeof selectedId === 'string'
+      ? selectedId
+      : (state.remoteSelectedKey || state.remoteActiveSessionKey || '');
+    populateRemoteSessionSelect(select, {
+      selectedKey: targetKey,
+      searchTerm
+    });
+    return;
+  }
+  const effectiveSelectedId = typeof selectedId === 'string' ? selectedId : state.activeVideoId;
   const searchTerm = (state.videoSearch || '').toLowerCase();
   const entries = state.cachedEntries
     .filter((entry) => entry?.hasVideo && entry.videoFilename && matchesEntrySearch(entry, searchTerm));
   populateSelect(select, entries, {
-    selectedId,
+    selectedId: effectiveSelectedId,
     placeholder: '選擇影片或音訊',
     emptyLabel: state.videoSearch ? '（沒有符合的媒體）' : '（尚未匯入媒體）',
     buildLabel: formatVideoOptionLabel,
@@ -2540,9 +2702,137 @@ function populateSelect(select, entries, {
   refreshCustomSelect(select, { rebuildOptions: true });
 }
 
+function normalizeRemoteSession(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const key = typeof raw.key === 'string' ? raw.key.trim() : '';
+  if (!key) return null;
+  const host = typeof raw.host === 'string' ? raw.host : '';
+  const status = typeof raw.status === 'string' ? raw.status.trim().toLowerCase() : 'unknown';
+  const lastUpdateRaw = Number(raw.lastUpdate);
+  const lastUpdate = Number.isFinite(lastUpdateRaw) ? lastUpdateRaw : 0;
+  const lastPlayTsRaw = Number(raw.lastPlayTs);
+  const lastPlayTs = Number.isFinite(lastPlayTsRaw) ? lastPlayTsRaw : 0;
+  const connected = raw.connected !== false;
+  let nowPlaying = null;
+  if (raw.nowPlaying && typeof raw.nowPlaying === 'object') {
+    const rawSessionKey = typeof raw.nowPlaying.sessionKey === 'string'
+      ? raw.nowPlaying.sessionKey
+      : (typeof raw.nowPlaying.session_key === 'string' ? raw.nowPlaying.session_key : '');
+    const artists = Array.isArray(raw.nowPlaying.artists)
+      ? raw.nowPlaying.artists.map((name) => (typeof name === 'string' ? name.trim() : '')).filter(Boolean)
+      : [];
+    nowPlaying = {
+      sessionKey: rawSessionKey ? rawSessionKey.trim() : key,
+      title: typeof raw.nowPlaying.title === 'string' ? raw.nowPlaying.title : '',
+      artists,
+      status: typeof raw.nowPlaying.status === 'string'
+        ? raw.nowPlaying.status.trim().toLowerCase()
+        : status,
+      songLink: typeof raw.nowPlaying.songLink === 'string' ? raw.nowPlaying.songLink : '',
+      platform: typeof raw.nowPlaying.platform === 'string' ? raw.nowPlaying.platform : '',
+      isLive: raw.nowPlaying.isLive === true
+    };
+  }
+  const resolvedStatus = (nowPlaying?.status || status || 'unknown').toLowerCase();
+  if (resolvedStatus === 'stopped') return null;
+  const searchParts = [key, host];
+  if (nowPlaying) {
+    if (nowPlaying.title) searchParts.push(nowPlaying.title);
+    if (nowPlaying.artists.length) searchParts.push(nowPlaying.artists.join(' '));
+    if (nowPlaying.platform) searchParts.push(nowPlaying.platform);
+    if (nowPlaying.songLink) searchParts.push(nowPlaying.songLink);
+  }
+  const searchText = searchParts
+    .filter(Boolean)
+    .map((value) => String(value).toLowerCase())
+    .join(' ');
+  return { key, host, status: resolvedStatus || 'unknown', lastUpdate, lastPlayTs, connected, nowPlaying, searchText };
+}
+
+function matchesRemoteSessionSearch(session, term) {
+  if (!term) return true;
+  return (session?.searchText || '').includes(term);
+}
+
+function formatRemoteSessionOptionLabel(session) {
+  if (!session) return '';
+  const nowPlaying = session.nowPlaying || null;
+  const host = session.host || '';
+  const title = nowPlaying?.title || '';
+  const artists = Array.isArray(nowPlaying?.artists) && nowPlaying.artists.length
+    ? nowPlaying.artists.join(', ')
+    : '';
+  const platform = nowPlaying?.platform || '';
+  const statusSource = nowPlaying?.status || session.status;
+  const parts = [];
+  if (host) parts.push(host);
+  if (title) parts.push(title);
+  else if (artists) parts.push(artists);
+  let label = parts.length ? parts.join(' · ') : (platform || session.key);
+  const statusLabel = getRemoteStatusLabel({
+    status: statusSource,
+    isLive: nowPlaying?.isLive,
+    title: nowPlaying?.title,
+    artists: nowPlaying?.artists
+  });
+  if (statusLabel) {
+    label += `（${statusLabel}）`;
+  }
+  return label;
+}
+
+function populateRemoteSessionSelect(select, { selectedKey = '', searchTerm = '' } = {}) {
+  const normalizedTerm = typeof searchTerm === 'string' ? searchTerm : '';
+  const sessions = state.remoteSessions.filter((session) => matchesRemoteSessionSearch(session, normalizedTerm));
+  select.innerHTML = '';
+  if (!sessions.length) {
+    const emptyLabel = state.remoteSessions.length
+      ? '（沒有符合的外部來源）'
+      : '（沒有外部播放來源）';
+    const option = new Option(emptyLabel, '');
+    option.disabled = true;
+    option.selected = true;
+    select.add(option);
+    select.disabled = true;
+    refreshCustomSelect(select, { rebuildOptions: true });
+    return;
+  }
+  select.disabled = false;
+  const placeholder = new Option('選擇要追蹤的頁面', '', !selectedKey, !selectedKey);
+  select.add(placeholder);
+  sessions.forEach((session) => {
+    const option = new Option(formatRemoteSessionOptionLabel(session), session.key, false, session.key === selectedKey);
+    const tooltipParts = [];
+    if (session.nowPlaying?.artists?.length) tooltipParts.push(session.nowPlaying.artists.join(', '));
+    if (session.nowPlaying?.platform) tooltipParts.push(session.nowPlaying.platform);
+    if (session.host && session.host !== session.nowPlaying?.platform) tooltipParts.push(session.host);
+    if (session.nowPlaying?.songLink) {
+      option.title = session.nowPlaying.songLink;
+    } else if (tooltipParts.length) {
+      option.title = tooltipParts.join(' · ');
+    }
+    select.add(option);
+  });
+  let finalValue = selectedKey;
+  if (!sessions.some((session) => session.key === finalValue)) {
+    const fallback = state.remoteActiveSessionKey;
+    if (fallback && sessions.some((session) => session.key === fallback)) {
+      finalValue = fallback;
+    } else {
+      finalValue = '';
+    }
+  }
+  select.value = finalValue;
+  refreshCustomSelect(select, { rebuildOptions: true });
+}
+
 function handleVideoCacheSearch() {
   state.videoSearch = (dom.videoCacheSearch?.value || '').trim();
-  updateVideoCacheSelect(state.activeVideoId);
+  if (state.useRemoteTimeline) {
+    updateVideoCacheSelect(state.remoteSelectedKey || state.remoteActiveSessionKey);
+  } else {
+    updateVideoCacheSelect(state.activeVideoId);
+  }
 }
 
 function handleSubsCacheSearch() {
@@ -2557,6 +2847,12 @@ function getEntryById(id) {
 
 function handleVideoCacheSelectChange() {
   const id = dom.videoCacheSelect?.value || '';
+  if (state.useRemoteTimeline) {
+    state.remoteSelectedKey = id;
+    overlaySync.setActiveSessionKey(id);
+    refreshCustomSelect(dom.videoCacheSelect);
+    return;
+  }
   state.activeVideoId = id;
   const entry = getEntryById(id);
   loadVideoEntry(entry);
@@ -2891,7 +3187,9 @@ async function handleLocalFileSelected(ev) {
 
   if (entry) {
     const merged = upsertCacheEntry(entry);
-    if (merged?.hasVideo && merged.videoFilename) {
+    if (state.useRemoteTimeline) {
+      updateVideoCacheSelect(state.remoteSelectedKey || state.remoteActiveSessionKey);
+    } else if (merged?.hasVideo && merged.videoFilename) {
       state.activeVideoId = merged.id;
       updateVideoCacheSelect(merged.id);
       await loadVideoEntry(merged);

--- a/src/renderer/app.mjs
+++ b/src/renderer/app.mjs
@@ -960,6 +960,7 @@ overlaySync.setNowPlayingHandler(handleRemoteNowPlaying);
 overlaySync.setRemoteSessionsHandler(handleRemoteSessionsUpdate);
 const REMOTE_TIME_EPSILON = 0.25;
 const REMOTE_STALL_TIME_MS = 1500;
+const REMOTE_SESSION_EXPIRY_MS = 10 * 60 * 1000;
 
 function looksLikeNowPlayingPayload(raw) {
   if (!raw || typeof raw !== 'object') return false;
@@ -1091,6 +1092,25 @@ function commitRemoteNowPlaying(payload, { derivedKeyHint = '' } = {}) {
   updateActiveCacheInfo();
 }
 
+function clearRemotePlaybackState() {
+  const hadRemote = Boolean(state.remoteNowPlaying);
+  const hadMediaKey = Boolean(state.remoteMediaKey);
+  state.remoteNowPlaying = null;
+  state.remoteLastGuid = '';
+  state.remoteLastUpdate = 0;
+  state.remoteMediaKey = '';
+  stopRemoteProgressTimer();
+  if (dom.video) {
+    dom.video.removeAttribute('data-remote-status');
+    dom.video.classList.remove('is-remote-playing', 'is-remote-paused');
+  }
+  updateRemotePlayerUi(null);
+  clearRemoteCover();
+  if (hadRemote || hadMediaKey) {
+    updateActiveCacheInfo();
+  }
+}
+
 function sanitizeRemoteIdentity(value, { lower = false } = {}) {
   if (typeof value !== 'string') return '';
   const trimmed = value.trim();
@@ -1181,6 +1201,7 @@ function handleRemoteSessionsUpdate(payload = {}) {
   state.remoteSelectedKey = normalized.some((session) => session.key === selectedKey) ? selectedKey : '';
   if (!normalized.length) {
     state.remoteSessionNowPlaying.clear();
+    clearRemotePlaybackState();
   } else {
     const allowedKeys = [];
     for (const session of normalized) {
@@ -1224,7 +1245,11 @@ function handleRemoteSessionsUpdate(payload = {}) {
     const snapshot = state.remoteSessionNowPlaying.get(trackedKey);
     if (snapshot) {
       commitRemoteNowPlaying(snapshot);
+    } else {
+      clearRemotePlaybackState();
     }
+  } else {
+    clearRemotePlaybackState();
   }
 }
 
@@ -2804,7 +2829,12 @@ function normalizeRemoteSession(raw) {
   const lastUpdate = Number.isFinite(lastUpdateRaw) ? lastUpdateRaw : 0;
   const lastPlayTsRaw = Number(raw.lastPlayTs);
   const lastPlayTs = Number.isFinite(lastPlayTsRaw) ? lastPlayTsRaw : 0;
+  const lastSeenRaw = Number(raw.lastSeen);
+  const lastSeen = Number.isFinite(lastSeenRaw) ? lastSeenRaw : 0;
   const connected = raw.connected !== false;
+  const activityTs = Math.max(lastUpdate, lastPlayTs, lastSeen);
+  const now = Date.now();
+  if (activityTs > 0 && now - activityTs > REMOTE_SESSION_EXPIRY_MS) return null;
   let nowPlaying = null;
   if (raw.nowPlaying && typeof raw.nowPlaying === 'object') {
     const rawSessionKey = typeof raw.nowPlaying.sessionKey === 'string'
@@ -2841,7 +2871,6 @@ function normalizeRemoteSession(raw) {
     };
   }
   const resolvedStatus = (nowPlaying?.status || status || 'unknown').toLowerCase();
-  if (resolvedStatus === 'stopped') return null;
   const searchParts = [key, host];
   if (nowPlaying) {
     if (nowPlaying.title) searchParts.push(nowPlaying.title);
@@ -2853,7 +2882,17 @@ function normalizeRemoteSession(raw) {
     .filter(Boolean)
     .map((value) => String(value).toLowerCase())
     .join(' ');
-  return { key, host, status: resolvedStatus || 'unknown', lastUpdate, lastPlayTs, connected, nowPlaying, searchText };
+  return {
+    key,
+    host,
+    status: resolvedStatus || 'unknown',
+    lastUpdate,
+    lastPlayTs,
+    lastSeen,
+    connected,
+    nowPlaying,
+    searchText
+  };
 }
 
 function matchesRemoteSessionSearch(session, term) {


### PR DESCRIPTION
## Summary
- derive an effective remote playback status that treats stale "playing" updates as paused and reuse it for HUD/video state
- stop the remote progress ticker when updates stop arriving so the overlay timeline freezes until playback resumes
- include session identifiers with remote payloads and ignore monitor updates from untracked sessions so other pages can't advance the paused timeline

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e244c366508328b5dbd641b38059e1